### PR TITLE
Change class prefix to "MGCD"

### DIFF
--- a/MqttCocoaAsyncSocket.xcodeproj/project.pbxproj
+++ b/MqttCocoaAsyncSocket.xcodeproj/project.pbxproj
@@ -10,27 +10,27 @@
 		4AB7B6A528E458AD003ED9BF /* MqttCocoaAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6A328E458AD003ED9BF /* MqttCocoaAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4AB7B6A928E458BB003ED9BF /* MqttCocoaAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6A328E458AD003ED9BF /* MqttCocoaAsyncSocket.h */; };
 		4AB7B6AA28E458BC003ED9BF /* MqttCocoaAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6A328E458AD003ED9BF /* MqttCocoaAsyncSocket.h */; };
-		4AB7B6D128E4592A003ED9BF /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* GCDAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AB7B6D228E4592A003ED9BF /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* GCDAsyncSocket.h */; };
-		4AB7B6D328E4592A003ED9BF /* GCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* GCDAsyncSocket.h */; };
-		4AB7B6D428E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* GCDAsyncUdpSocket.m */; };
-		4AB7B6D528E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* GCDAsyncUdpSocket.m */; };
-		4AB7B6D628E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* GCDAsyncUdpSocket.m */; };
-		4AB7B6D728E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* GCDAsyncUdpSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4AB7B6D828E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* GCDAsyncUdpSocket.h */; };
-		4AB7B6D928E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* GCDAsyncUdpSocket.h */; };
-		4AB7B6DA28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* GCDAsyncSocket.m */; };
-		4AB7B6DB28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* GCDAsyncSocket.m */; };
-		4AB7B6DC28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* GCDAsyncSocket.m */; };
+		4AB7B6D128E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* MGCDAsyncSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4AB7B6D228E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* MGCDAsyncSocket.h */; };
+		4AB7B6D328E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CD28E4592A003ED9BF /* MGCDAsyncSocket.h */; };
+		4AB7B6D428E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* MGCDAsyncUdpSocket.m */; };
+		4AB7B6D528E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* MGCDAsyncUdpSocket.m */; };
+		4AB7B6D628E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6CE28E4592A003ED9BF /* MGCDAsyncUdpSocket.m */; };
+		4AB7B6D728E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* MGCDAsyncUdpSocket.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4AB7B6D828E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* MGCDAsyncUdpSocket.h */; };
+		4AB7B6D928E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AB7B6CF28E4592A003ED9BF /* MGCDAsyncUdpSocket.h */; };
+		4AB7B6DA28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* MGCDAsyncSocket.m */; };
+		4AB7B6DB28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* MGCDAsyncSocket.m */; };
+		4AB7B6DC28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */ = {isa = PBXBuildFile; fileRef = 4AB7B6D028E4592A003ED9BF /* MGCDAsyncSocket.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		4AB7B6A328E458AD003ED9BF /* MqttCocoaAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MqttCocoaAsyncSocket.h; sourceTree = "<group>"; };
 		4AB7B6A428E458AD003ED9BF /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		4AB7B6CD28E4592A003ED9BF /* GCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncSocket.h; sourceTree = "<group>"; };
-		4AB7B6CE28E4592A003ED9BF /* GCDAsyncUdpSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncUdpSocket.m; sourceTree = "<group>"; };
-		4AB7B6CF28E4592A003ED9BF /* GCDAsyncUdpSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCDAsyncUdpSocket.h; sourceTree = "<group>"; };
-		4AB7B6D028E4592A003ED9BF /* GCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GCDAsyncSocket.m; sourceTree = "<group>"; };
+		4AB7B6CD28E4592A003ED9BF /* MGCDAsyncSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGCDAsyncSocket.h; sourceTree = "<group>"; };
+		4AB7B6CE28E4592A003ED9BF /* MGCDAsyncUdpSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGCDAsyncUdpSocket.m; sourceTree = "<group>"; };
+		4AB7B6CF28E4592A003ED9BF /* MGCDAsyncUdpSocket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MGCDAsyncUdpSocket.h; sourceTree = "<group>"; };
+		4AB7B6D028E4592A003ED9BF /* MGCDAsyncSocket.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MGCDAsyncSocket.m; sourceTree = "<group>"; };
 		6CD990101B77868C0011A685 /* MqttCocoaAsyncSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MqttCocoaAsyncSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7D8B70C41BCFA15700D8E273 /* MqttCocoaAsyncSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MqttCocoaAsyncSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9FC41F131B9D965000578BEB /* MqttCocoaAsyncSocket.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MqttCocoaAsyncSocket.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -64,10 +64,10 @@
 		4AB7B6CC28E45913003ED9BF /* GCD */ = {
 			isa = PBXGroup;
 			children = (
-				4AB7B6CD28E4592A003ED9BF /* GCDAsyncSocket.h */,
-				4AB7B6D028E4592A003ED9BF /* GCDAsyncSocket.m */,
-				4AB7B6CF28E4592A003ED9BF /* GCDAsyncUdpSocket.h */,
-				4AB7B6CE28E4592A003ED9BF /* GCDAsyncUdpSocket.m */,
+				4AB7B6CD28E4592A003ED9BF /* MGCDAsyncSocket.h */,
+				4AB7B6D028E4592A003ED9BF /* MGCDAsyncSocket.m */,
+				4AB7B6CF28E4592A003ED9BF /* MGCDAsyncUdpSocket.h */,
+				4AB7B6CE28E4592A003ED9BF /* MGCDAsyncUdpSocket.m */,
 			);
 			path = GCD;
 			sourceTree = "<group>";
@@ -108,8 +108,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4AB7B6A528E458AD003ED9BF /* MqttCocoaAsyncSocket.h in Headers */,
-				4AB7B6D728E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */,
-				4AB7B6D128E4592A003ED9BF /* GCDAsyncSocket.h in Headers */,
+				4AB7B6D728E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */,
+				4AB7B6D128E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,8 +118,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4AB7B6AA28E458BC003ED9BF /* MqttCocoaAsyncSocket.h in Headers */,
-				4AB7B6D928E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */,
-				4AB7B6D328E4592A003ED9BF /* GCDAsyncSocket.h in Headers */,
+				4AB7B6D928E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */,
+				4AB7B6D328E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -128,8 +128,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				4AB7B6A928E458BB003ED9BF /* MqttCocoaAsyncSocket.h in Headers */,
-				4AB7B6D828E4592A003ED9BF /* GCDAsyncUdpSocket.h in Headers */,
-				4AB7B6D228E4592A003ED9BF /* GCDAsyncSocket.h in Headers */,
+				4AB7B6D828E4592A003ED9BF /* MGCDAsyncUdpSocket.h in Headers */,
+				4AB7B6D228E4592A003ED9BF /* MGCDAsyncSocket.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,8 +262,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AB7B6DA28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */,
-				4AB7B6D428E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */,
+				4AB7B6DA28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */,
+				4AB7B6D428E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -271,8 +271,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AB7B6DC28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */,
-				4AB7B6D628E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */,
+				4AB7B6DC28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */,
+				4AB7B6D628E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -280,8 +280,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AB7B6DB28E4592A003ED9BF /* GCDAsyncSocket.m in Sources */,
-				4AB7B6D528E4592A003ED9BF /* GCDAsyncUdpSocket.m in Sources */,
+				4AB7B6DB28E4592A003ED9BF /* MGCDAsyncSocket.m in Sources */,
+				4AB7B6D528E4592A003ED9BF /* MGCDAsyncUdpSocket.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/GCD/MGCDAsyncSocket.h
+++ b/Source/GCD/MGCDAsyncSocket.h
@@ -1,5 +1,5 @@
 //  
-//  GCDAsyncSocket.h
+//  MGCDAsyncSocket.h
 //  
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson in Q3 2010.
@@ -16,50 +16,50 @@
 
 #include <sys/socket.h> // AF_INET, AF_INET6
 
-@class GCDAsyncReadPacket;
-@class GCDAsyncWritePacket;
-@class GCDAsyncSocketPreBuffer;
-@protocol GCDAsyncSocketDelegate;
+@class MGCDAsyncReadPacket;
+@class MGCDAsyncWritePacket;
+@class MGCDAsyncSocketPreBuffer;
+@protocol MGCDAsyncSocketDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const GCDAsyncSocketException;
-extern NSString *const GCDAsyncSocketErrorDomain;
+extern NSString *const MGCDAsyncSocketException;
+extern NSString *const MGCDAsyncSocketErrorDomain;
 
-extern NSString *const GCDAsyncSocketQueueName;
-extern NSString *const GCDAsyncSocketThreadName;
+extern NSString *const MGCDAsyncSocketQueueName;
+extern NSString *const MGCDAsyncSocketThreadName;
 
-extern NSString *const GCDAsyncSocketManuallyEvaluateTrust;
+extern NSString *const MGCDAsyncSocketManuallyEvaluateTrust;
 #if TARGET_OS_IPHONE
-extern NSString *const GCDAsyncSocketUseCFStreamForTLS;
+extern NSString *const MGCDAsyncSocketUseCFStreamForTLS;
 #endif
-#define GCDAsyncSocketSSLPeerName     (NSString *)kCFStreamSSLPeerName
-#define GCDAsyncSocketSSLCertificates (NSString *)kCFStreamSSLCertificates
-#define GCDAsyncSocketSSLIsServer     (NSString *)kCFStreamSSLIsServer
-extern NSString *const GCDAsyncSocketSSLPeerID;
-extern NSString *const GCDAsyncSocketSSLProtocolVersionMin;
-extern NSString *const GCDAsyncSocketSSLProtocolVersionMax;
-extern NSString *const GCDAsyncSocketSSLSessionOptionFalseStart;
-extern NSString *const GCDAsyncSocketSSLSessionOptionSendOneByteRecord;
-extern NSString *const GCDAsyncSocketSSLCipherSuites;
-extern NSString *const GCDAsyncSocketSSLALPN;
+#define MGCDAsyncSocketSSLPeerName     (NSString *)kCFStreamSSLPeerName
+#define MGCDAsyncSocketSSLCertificates (NSString *)kCFStreamSSLCertificates
+#define MGCDAsyncSocketSSLIsServer     (NSString *)kCFStreamSSLIsServer
+extern NSString *const MGCDAsyncSocketSSLPeerID;
+extern NSString *const MGCDAsyncSocketSSLProtocolVersionMin;
+extern NSString *const MGCDAsyncSocketSSLProtocolVersionMax;
+extern NSString *const MGCDAsyncSocketSSLSessionOptionFalseStart;
+extern NSString *const MGCDAsyncSocketSSLSessionOptionSendOneByteRecord;
+extern NSString *const MGCDAsyncSocketSSLCipherSuites;
+extern NSString *const MGCDAsyncSocketSSLALPN;
 #if !TARGET_OS_IPHONE
-extern NSString *const GCDAsyncSocketSSLDiffieHellmanParameters;
+extern NSString *const MGCDAsyncSocketSSLDiffieHellmanParameters;
 #endif
 
-#define GCDAsyncSocketLoggingContext 65535
+#define MGCDAsyncSocketLoggingContext 65535
 
 
-typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
-	GCDAsyncSocketNoError = 0,           // Never used
-	GCDAsyncSocketBadConfigError,        // Invalid configuration
-	GCDAsyncSocketBadParamError,         // Invalid parameter was passed
-	GCDAsyncSocketConnectTimeoutError,   // A connect operation timed out
-	GCDAsyncSocketReadTimeoutError,      // A read operation timed out
-	GCDAsyncSocketWriteTimeoutError,     // A write operation timed out
-	GCDAsyncSocketReadMaxedOutError,     // Reached set maxLength without completing
-	GCDAsyncSocketClosedError,           // The remote peer closed the connection
-	GCDAsyncSocketOtherError,            // Description provided in userInfo
+typedef NS_ERROR_ENUM(MGCDAsyncSocketErrorDomain, MGCDAsyncSocketError) {
+	MGCDAsyncSocketNoError = 0,           // Never used
+	MGCDAsyncSocketBadConfigError,        // Invalid configuration
+	MGCDAsyncSocketBadParamError,         // Invalid parameter was passed
+	MGCDAsyncSocketConnectTimeoutError,   // A connect operation timed out
+	MGCDAsyncSocketReadTimeoutError,      // A read operation timed out
+	MGCDAsyncSocketWriteTimeoutError,     // A write operation timed out
+	MGCDAsyncSocketReadMaxedOutError,     // Reached set maxLength without completing
+	MGCDAsyncSocketClosedError,           // The remote peer closed the connection
+	MGCDAsyncSocketOtherError,            // Description provided in userInfo
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -67,10 +67,10 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 
-@interface GCDAsyncSocket : NSObject
+@interface MGCDAsyncSocket : NSObject
 
 /**
- * GCDAsyncSocket uses the standard delegate paradigm,
+ * MGCDAsyncSocket uses the standard delegate paradigm,
  * but executes all delegate callbacks on a given delegate dispatch queue.
  * This allows for maximum concurrency, while at the same time providing easy thread safety.
  * 
@@ -78,7 +78,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * use the socket, or you will get an error.
  * 
  * The socket queue is optional.
- * If you pass NULL, GCDAsyncSocket will automatically create it's own socket queue.
+ * If you pass NULL, MGCDAsyncSocket will automatically create it's own socket queue.
  * If you choose to provide a socket queue, the socket queue must not be a concurrent queue.
  * If you choose to provide a socket queue, and the socket queue has a configured target queue,
  * then please see the discussion for the method markSocketQueueTargetQueue.
@@ -87,47 +87,47 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 **/
 - (instancetype)init;
 - (instancetype)initWithSocketQueue:(nullable dispatch_queue_t)sq;
-- (instancetype)initWithDelegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq;
-- (instancetype)initWithDelegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq;
+- (instancetype)initWithDelegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq NS_DESIGNATED_INITIALIZER;
 
 /**
- * Create GCDAsyncSocket from already connect BSD socket file descriptor
+ * Create MGCDAsyncSocket from already connect BSD socket file descriptor
 **/
 + (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD socketQueue:(nullable dispatch_queue_t)sq error:(NSError**)error;
 
-+ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq error:(NSError**)error;
++ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq error:(NSError**)error;
 
-+ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq error:(NSError **)error;
++ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq error:(NSError **)error;
 
 #pragma mark Configuration
 
-@property (atomic, weak, readwrite, nullable) id<GCDAsyncSocketDelegate> delegate;
+@property (atomic, weak, readwrite, nullable) id<MGCDAsyncSocketDelegate> delegate;
 #if OS_OBJECT_USE_OBJC
 @property (atomic, strong, readwrite, nullable) dispatch_queue_t delegateQueue;
 #else
 @property (atomic, assign, readwrite, nullable) dispatch_queue_t delegateQueue;
 #endif
 
-- (void)getDelegate:(id<GCDAsyncSocketDelegate> __nullable * __nullable)delegatePtr delegateQueue:(dispatch_queue_t __nullable * __nullable)delegateQueuePtr;
-- (void)setDelegate:(nullable id<GCDAsyncSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
+- (void)getDelegate:(id<MGCDAsyncSocketDelegate> __nullable * __nullable)delegatePtr delegateQueue:(dispatch_queue_t __nullable * __nullable)delegateQueuePtr;
+- (void)setDelegate:(nullable id<MGCDAsyncSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
 
 /**
  * If you are setting the delegate to nil within the delegate's dealloc method,
  * you may need to use the synchronous versions below.
 **/
-- (void)synchronouslySetDelegate:(nullable id<GCDAsyncSocketDelegate>)delegate;
+- (void)synchronouslySetDelegate:(nullable id<MGCDAsyncSocketDelegate>)delegate;
 - (void)synchronouslySetDelegateQueue:(nullable dispatch_queue_t)delegateQueue;
-- (void)synchronouslySetDelegate:(nullable id<GCDAsyncSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
+- (void)synchronouslySetDelegate:(nullable id<MGCDAsyncSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
 
 /**
  * By default, both IPv4 and IPv6 are enabled.
  * 
- * For accepting incoming connections, this means GCDAsyncSocket automatically supports both protocols,
+ * For accepting incoming connections, this means MGCDAsyncSocket automatically supports both protocols,
  * and can simulataneously accept incoming connections on either protocol.
  * 
- * For outgoing connections, this means GCDAsyncSocket can connect to remote hosts running either protocol.
- * If a DNS lookup returns only IPv4 results, GCDAsyncSocket will automatically use IPv4.
- * If a DNS lookup returns only IPv6 results, GCDAsyncSocket will automatically use IPv6.
+ * For outgoing connections, this means MGCDAsyncSocket can connect to remote hosts running either protocol.
+ * If a DNS lookup returns only IPv4 results, MGCDAsyncSocket will automatically use IPv4.
+ * If a DNS lookup returns only IPv6 results, MGCDAsyncSocket will automatically use IPv6.
  * If a DNS lookup returns both IPv4 and IPv6 results, the preferred protocol will be chosen.
  * By default, the preferred protocol is IPv4, but may be configured as desired.
 **/
@@ -155,7 +155,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 
 /**
  * Tells the socket to begin listening and accepting connections on the given port.
- * When a connection is accepted, a new instance of GCDAsyncSocket will be spawned to handle it,
+ * When a connection is accepted, a new instance of MGCDAsyncSocket will be spawned to handle it,
  * and the socket:didAcceptNewSocket: delegate method will be invoked.
  * 
  * The socket will listen on all available interfaces (e.g. wifi, ethernet, etc)
@@ -182,7 +182,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 
 /**
  * Tells the socket to begin listening and accepting connections on the unix domain at the given url.
- * When a connection is accepted, a new instance of GCDAsyncSocket will be spawned to handle it,
+ * When a connection is accepted, a new instance of MGCDAsyncSocket will be spawned to handle it,
  * and the socket:didAcceptNewSocket: delegate method will be invoked.
  *
  * The socket will listen on all available interfaces (e.g. wifi, ethernet, etc)
@@ -324,7 +324,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * will be queued onto the delegateQueue asynchronously (behind any previously queued delegate methods).
  * In other words, the disconnected delegate method will be invoked sometime shortly after this method returns.
  * 
- * Please note the recommended way of releasing a GCDAsyncSocket instance (e.g. in a dealloc method)
+ * Please note the recommended way of releasing a MGCDAsyncSocket instance (e.g. in a dealloc method)
  * [asyncSocket setDelegate:nil];
  * [asyncSocket disconnect];
  * [asyncSocket release];
@@ -572,7 +572,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * If maxLength is zero, no length restriction is enforced.
  * Otherwise if maxLength bytes are read without completing the read,
- * it is treated similarly to a timeout - the socket is closed with a GCDAsyncSocketReadMaxedOutError.
+ * it is treated similarly to a timeout - the socket is closed with a MGCDAsyncSocketReadMaxedOutError.
  * The read will complete successfully if exactly maxLength bytes are read and the given data is found at the end.
  * 
  * If you pass nil or zero-length data as the "data" parameter,
@@ -605,7 +605,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * If maxLength is zero, no length restriction is enforced.
  * Otherwise if maxLength bytes are read without completing the read,
- * it is treated similarly to a timeout - the socket is closed with a GCDAsyncSocketReadMaxedOutError.
+ * it is treated similarly to a timeout - the socket is closed with a MGCDAsyncSocketReadMaxedOutError.
  * The read will complete successfully if exactly maxLength bytes are read and the given data is found at the end.
  * 
  * If you pass a maxLength parameter that is less than the length of the data (separator) parameter,
@@ -656,7 +656,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * If the given data parameter is mutable (NSMutableData) then you MUST NOT alter the data while
  * the socket is writing it. In other words, it's not safe to alter the data until after the delegate method
  * socket:didWriteDataWithTag: is invoked signifying that this particular write operation has completed.
- * This is due to the fact that GCDAsyncSocket does NOT copy the data. It simply retains it.
+ * This is due to the fact that MGCDAsyncSocket does NOT copy the data. It simply retains it.
  * This is for performance reasons. Often times, if NSMutableData is passed, it is because
  * a request/response was built up in memory. Copying this data adds an unwanted/unneeded overhead.
  * If you need to write data from an immutable buffer, and you need to alter the buffer before the socket
@@ -683,12 +683,12 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  *
  * ==== The available TOP-LEVEL KEYS are:
  * 
- * - GCDAsyncSocketManuallyEvaluateTrust
+ * - MGCDAsyncSocketManuallyEvaluateTrust
  *     The value must be of type NSNumber, encapsulating a BOOL value.
  *     If you set this to YES, then the underlying SecureTransport system will not evaluate the SecTrustRef of the peer.
  *     Instead it will pause at the moment evaulation would typically occur,
  *     and allow us to handle the security evaluation however we see fit.
- *     So GCDAsyncSocket will invoke the delegate method socket:shouldTrustPeer: passing the SecTrustRef.
+ *     So MGCDAsyncSocket will invoke the delegate method socket:shouldTrustPeer: passing the SecTrustRef.
  *
  *     Note that if you set this option, then all other configuration keys are ignored.
  *     Evaluation will be completely up to you during the socket:didReceiveTrust:completionHandler: delegate method.
@@ -699,18 +699,18 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  *     
  *     If unspecified, the default value is NO.
  *
- * - GCDAsyncSocketUseCFStreamForTLS (iOS only)
+ * - MGCDAsyncSocketUseCFStreamForTLS (iOS only)
  *     The value must be of type NSNumber, encapsulating a BOOL value.
- *     By default GCDAsyncSocket will use the SecureTransport layer to perform encryption.
+ *     By default MGCDAsyncSocket will use the SecureTransport layer to perform encryption.
  *     This gives us more control over the security protocol (many more configuration options),
  *     plus it allows us to optimize things like sys calls and buffer allocation.
  *     
- *     However, if you absolutely must, you can instruct GCDAsyncSocket to use the old-fashioned encryption
- *     technique by going through the CFStream instead. So instead of using SecureTransport, GCDAsyncSocket
+ *     However, if you absolutely must, you can instruct MGCDAsyncSocket to use the old-fashioned encryption
+ *     technique by going through the CFStream instead. So instead of using SecureTransport, MGCDAsyncSocket
  *     will instead setup a CFRead/CFWriteStream. And then set the kCFStreamPropertySSLSettings property
  *     (via CFReadStreamSetProperty / CFWriteStreamSetProperty) and will pass the given options to this method.
  *     
- *     Thus all the other keys in the given dictionary will be ignored by GCDAsyncSocket,
+ *     Thus all the other keys in the given dictionary will be ignored by MGCDAsyncSocket,
  *     and will passed directly CFReadStreamSetProperty / CFWriteStreamSetProperty.
  *     For more infomation on these keys, please see the documentation for kCFStreamPropertySSLSettings.
  *
@@ -733,55 +733,55 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  *     This is optional for iOS. If not supplied, a NO value is the default.
  *     This is not needed for Mac OS X, and the value is ignored.
  *
- * - GCDAsyncSocketSSLPeerID
+ * - MGCDAsyncSocketSSLPeerID
  *     The value must be of type NSData.
  *     You must set this value if you want to use TLS session resumption.
  *     See Apple's documentation for SSLSetPeerID.
  *
- * - GCDAsyncSocketSSLProtocolVersionMin
- * - GCDAsyncSocketSSLProtocolVersionMax
+ * - MGCDAsyncSocketSSLProtocolVersionMin
+ * - MGCDAsyncSocketSSLProtocolVersionMax
  *     The value(s) must be of type NSNumber, encapsulting a SSLProtocol value.
  *     See Apple's documentation for SSLSetProtocolVersionMin & SSLSetProtocolVersionMax.
  *     See also the SSLProtocol typedef.
  * 
- * - GCDAsyncSocketSSLSessionOptionFalseStart
+ * - MGCDAsyncSocketSSLSessionOptionFalseStart
  *     The value must be of type NSNumber, encapsulating a BOOL value.
  *     See Apple's documentation for kSSLSessionOptionFalseStart.
  * 
- * - GCDAsyncSocketSSLSessionOptionSendOneByteRecord
+ * - MGCDAsyncSocketSSLSessionOptionSendOneByteRecord
  *     The value must be of type NSNumber, encapsulating a BOOL value.
  *     See Apple's documentation for kSSLSessionOptionSendOneByteRecord.
  * 
- * - GCDAsyncSocketSSLCipherSuites
+ * - MGCDAsyncSocketSSLCipherSuites
  *     The values must be of type NSArray.
  *     Each item within the array must be a NSNumber, encapsulating an SSLCipherSuite.
  *     See Apple's documentation for SSLSetEnabledCiphers.
  *     See also the SSLCipherSuite typedef.
  *
- * - GCDAsyncSocketSSLDiffieHellmanParameters (Mac OS X only)
+ * - MGCDAsyncSocketSSLDiffieHellmanParameters (Mac OS X only)
  *     The value must be of type NSData.
  *     See Apple's documentation for SSLSetDiffieHellmanParams.
  * 
  * ==== The following UNAVAILABLE KEYS are: (with throw an exception)
  * 
  * - kCFStreamSSLAllowsAnyRoot (UNAVAILABLE)
- *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     You MUST use manual trust evaluation instead (see MGCDAsyncSocketManuallyEvaluateTrust).
  *     Corresponding deprecated method: SSLSetAllowsAnyRoot
  * 
  * - kCFStreamSSLAllowsExpiredRoots (UNAVAILABLE)
- *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     You MUST use manual trust evaluation instead (see MGCDAsyncSocketManuallyEvaluateTrust).
  *     Corresponding deprecated method: SSLSetAllowsExpiredRoots
  *
  * - kCFStreamSSLAllowsExpiredCertificates (UNAVAILABLE)
- *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     You MUST use manual trust evaluation instead (see MGCDAsyncSocketManuallyEvaluateTrust).
  *     Corresponding deprecated method: SSLSetAllowsExpiredCerts
  *
  * - kCFStreamSSLValidatesCertificateChain (UNAVAILABLE)
- *     You MUST use manual trust evaluation instead (see GCDAsyncSocketManuallyEvaluateTrust).
+ *     You MUST use manual trust evaluation instead (see MGCDAsyncSocketManuallyEvaluateTrust).
  *     Corresponding deprecated method: SSLSetEnableCertVerify
  *
  * - kCFStreamSSLLevel (UNAVAILABLE)
- *     You MUST use GCDAsyncSocketSSLProtocolVersionMin & GCDAsyncSocketSSLProtocolVersionMin instead.
+ *     You MUST use MGCDAsyncSocketSSLProtocolVersionMin & MGCDAsyncSocketSSLProtocolVersionMin instead.
  *     Corresponding deprecated method: SSLSetProtocolVersionEnabled
  *
  * 
@@ -841,7 +841,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 @property (atomic, assign, readwrite) BOOL autoDisconnectOnClosedReadStream;
 
 /**
- * GCDAsyncSocket maintains thread safety by using an internal serial dispatch_queue.
+ * MGCDAsyncSocket maintains thread safety by using an internal serial dispatch_queue.
  * In most cases, the instance creates this queue itself.
  * However, to allow for maximum flexibility, the internal queue may be passed in the init method.
  * This allows for some advanced options such as controlling socket priority via target queues.
@@ -874,7 +874,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * }
  * 
  * What happens if you call this method from the socketTargetQueue? The result is deadlock.
- * This is because the GCD API offers no mechanism to discover a queue's targetQueue.
+ * This is because the MGCD API offers no mechanism to discover a queue's targetQueue.
  * Thus we have no idea if our socketQueue is configured with a targetQueue.
  * If we had this information, we could easily avoid deadlock.
  * But, since these API's are missing or unfeasible, you'll have to explicitly set it.
@@ -893,7 +893,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * Additionally, networking traffic from a single IP cannot monopolize the module.
  * 
  * Here's how you would accomplish something like that:
- * - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(GCDAsyncSocket *)sock
+ * - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(MGCDAsyncSocket *)sock
  * {
  *     dispatch_queue_t socketQueue = dispatch_queue_create("", NULL);
  *     dispatch_queue_t ipQueue = [self ipQueueForAddress:address];
@@ -903,7 +903,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  *     
  *     return socketQueue;
  * }
- * - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket
+ * - (void)socket:(MGCDAsyncSocket *)sock didAcceptNewSocket:(MGCDAsyncSocket *)newSocket
  * {
  *     [clientConnections addObject:newSocket];
  *     [newSocket markSocketQueueTargetQueue:moduleQueue];
@@ -974,7 +974,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * - If a socket doesn't have backgrounding enabled, and that socket is closed while the app is backgrounded,
  *   Apple only bothers to notify us via the CFStream API.
- *   The faster and more powerful GCD API isn't notified properly in this case.
+ *   The faster and more powerful MGCD API isn't notified properly in this case.
  * 
  * See also: (BOOL)enableBackgroundingOnSocket
 **/
@@ -999,7 +999,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * Example usage:
  * 
- * - (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port
+ * - (void)socket:(MGCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port
  * {
  *     [asyncSocket performBlock:^{
  *         [asyncSocket enableBackgroundingOnSocket];
@@ -1061,7 +1061,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@protocol GCDAsyncSocketDelegate <NSObject>
+@protocol MGCDAsyncSocketDelegate <NSObject>
 @optional
 
 /**
@@ -1082,7 +1082,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * dispatch_retain(myExistingQueue);
  * return myExistingQueue;
 **/
-- (nullable dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(GCDAsyncSocket *)sock;
+- (nullable dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(MGCDAsyncSocket *)sock;
 
 /**
  * Called when a socket accepts a connection.
@@ -1094,43 +1094,43 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * By default the new socket will have the same delegate and delegateQueue.
  * You may, of course, change this at any time.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket;
+- (void)socket:(MGCDAsyncSocket *)sock didAcceptNewSocket:(MGCDAsyncSocket *)newSocket;
 
 /**
  * Called when a socket connects and is ready for reading and writing.
  * The host parameter will be an IP address, not a DNS name.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
+- (void)socket:(MGCDAsyncSocket *)sock didConnectToHost:(NSString *)host port:(uint16_t)port;
 
 /**
  * Called when a socket connects and is ready for reading and writing.
  * The host parameter will be an IP address, not a DNS name.
  **/
-- (void)socket:(GCDAsyncSocket *)sock didConnectToUrl:(NSURL *)url;
+- (void)socket:(MGCDAsyncSocket *)sock didConnectToUrl:(NSURL *)url;
 
 /**
  * Called when a socket has completed reading the requested data into memory.
  * Not called if there is an error.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
+- (void)socket:(MGCDAsyncSocket *)sock didReadData:(NSData *)data withTag:(long)tag;
 
 /**
  * Called when a socket has read in data, but has not yet completed the read.
  * This would occur if using readToData: or readToLength: methods.
  * It may be used for things such as updating progress bars.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
+- (void)socket:(MGCDAsyncSocket *)sock didReadPartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
 
 /**
  * Called when a socket has completed writing the requested data. Not called if there is an error.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didWriteDataWithTag:(long)tag;
+- (void)socket:(MGCDAsyncSocket *)sock didWriteDataWithTag:(long)tag;
 
 /**
  * Called when a socket has written some data, but has not yet completed the entire write.
  * It may be used for things such as updating progress bars.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didWritePartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
+- (void)socket:(MGCDAsyncSocket *)sock didWritePartialDataOfLength:(NSUInteger)partialLength tag:(long)tag;
 
 /**
  * Called if a read operation has reached its timeout without completing.
@@ -1143,7 +1143,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * Note that this method may be called multiple times for a single read if you return positive numbers.
 **/
-- (NSTimeInterval)socket:(GCDAsyncSocket *)sock shouldTimeoutReadWithTag:(long)tag
+- (NSTimeInterval)socket:(MGCDAsyncSocket *)sock shouldTimeoutReadWithTag:(long)tag
                                                                  elapsed:(NSTimeInterval)elapsed
                                                                bytesDone:(NSUInteger)length;
 
@@ -1158,7 +1158,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * Note that this method may be called multiple times for a single write if you return positive numbers.
 **/
-- (NSTimeInterval)socket:(GCDAsyncSocket *)sock shouldTimeoutWriteWithTag:(long)tag
+- (NSTimeInterval)socket:(MGCDAsyncSocket *)sock shouldTimeoutWriteWithTag:(long)tag
                                                                   elapsed:(NSTimeInterval)elapsed
                                                                 bytesDone:(NSUInteger)length;
 
@@ -1168,7 +1168,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * This delegate method is only called if autoDisconnectOnClosedReadStream has been set to NO.
  * See the discussion on the autoDisconnectOnClosedReadStream method for more information.
 **/
-- (void)socketDidCloseReadStream:(GCDAsyncSocket *)sock;
+- (void)socketDidCloseReadStream:(MGCDAsyncSocket *)sock;
 
 /**
  * Called when a socket disconnects with or without error.
@@ -1177,7 +1177,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * then an invocation of this delegate method will be enqueued on the delegateQueue
  * before the disconnect method returns.
  * 
- * Note: If the GCDAsyncSocket instance is deallocated while it is still connected,
+ * Note: If the MGCDAsyncSocket instance is deallocated while it is still connected,
  * and the delegate is not also deallocated, then this method will be invoked,
  * but the sock parameter will be nil. (It must necessarily be nil since it is no longer available.)
  * This is a generally rare, but is possible if one writes code like this:
@@ -1191,7 +1191,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * 
  * Of course, this depends on how your state machine is configured.
 **/
-- (void)socketDidDisconnect:(GCDAsyncSocket *)sock withError:(nullable NSError *)err;
+- (void)socketDidDisconnect:(MGCDAsyncSocket *)sock withError:(nullable NSError *)err;
 
 /**
  * Called after the socket has successfully completed SSL/TLS negotiation.
@@ -1200,13 +1200,13 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * If a SSL/TLS negotiation fails (invalid certificate, etc) then the socket will immediately close,
  * and the socketDidDisconnect:withError: delegate method will be called with the specific SSL error code.
 **/
-- (void)socketDidSecure:(GCDAsyncSocket *)sock;
+- (void)socketDidSecure:(MGCDAsyncSocket *)sock;
 
 /**
  * Allows a socket delegate to hook into the TLS handshake and manually validate the peer it's connecting to.
  *
  * This is only called if startTLS is invoked with options that include:
- * - GCDAsyncSocketManuallyEvaluateTrust == YES
+ * - MGCDAsyncSocketManuallyEvaluateTrust == YES
  *
  * Typically the delegate will use SecTrustEvaluate (and related functions) to properly validate the peer.
  * 
@@ -1219,7 +1219,7 @@ typedef NS_ERROR_ENUM(GCDAsyncSocketErrorDomain, GCDAsyncSocketError) {
  * The completionHandler block is thread-safe, and may be invoked from a background queue/thread.
  * It is safe to invoke the completionHandler block even if the socket has been closed.
 **/
-- (void)socket:(GCDAsyncSocket *)sock didReceiveTrust:(SecTrustRef)trust
+- (void)socket:(MGCDAsyncSocket *)sock didReceiveTrust:(SecTrustRef)trust
                                     completionHandler:(void (^)(BOOL shouldTrustPeer))completionHandler;
 
 @end

--- a/Source/GCD/MGCDAsyncSocket.m
+++ b/Source/GCD/MGCDAsyncSocket.m
@@ -1,5 +1,5 @@
 //
-//  GCDAsyncSocket.m
+//  MGCDAsyncSocket.m
 //  
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson in Q4 2010.
@@ -8,7 +8,7 @@
 //  https://github.com/robbiehanson/CocoaAsyncSocket
 //
 
-#import "GCDAsyncSocket.h"
+#import "MGCDAsyncSocket.h"
 
 #if TARGET_OS_IPHONE
 #import <CFNetwork/CFNetwork.h>
@@ -35,22 +35,22 @@
 #endif
 
 
-#ifndef GCDAsyncSocketLoggingEnabled
-#define GCDAsyncSocketLoggingEnabled 0
+#ifndef MGCDAsyncSocketLoggingEnabled
+#define MGCDAsyncSocketLoggingEnabled 0
 #endif
 
-#if GCDAsyncSocketLoggingEnabled
+#if MGCDAsyncSocketLoggingEnabled
 
 // Logging Enabled - See log level below
 
-// Logging uses the CocoaLumberjack framework (which is also GCD based).
+// Logging uses the CocoaLumberjack framework (which is also MGCD based).
 // https://github.com/robbiehanson/CocoaLumberjack
 // 
 // It allows us to do a lot of logging without significantly slowing down the code.
 #import "DDLog.h"
 
 #define LogAsync   YES
-#define LogContext GCDAsyncSocketLoggingContext
+#define LogContext MGCDAsyncSocketLoggingContext
 
 #define LogObjc(flg, frmt, ...) LOG_OBJC_MAYBE(LogAsync, logLevel, flg, LogContext, frmt, ##__VA_ARGS__)
 #define LogC(flg, frmt, ...)    LOG_C_MAYBE(LogAsync, logLevel, flg, LogContext, frmt, ##__VA_ARGS__)
@@ -68,12 +68,12 @@
 #define LogTrace()              LogObjc(LOG_FLAG_VERBOSE, @"%@: %@", THIS_FILE, THIS_METHOD)
 #define LogCTrace()             LogC(LOG_FLAG_VERBOSE, @"%@: %s", THIS_FILE, __FUNCTION__)
 
-#ifndef GCDAsyncSocketLogLevel
-#define GCDAsyncSocketLogLevel LOG_LEVEL_VERBOSE
+#ifndef MGCDAsyncSocketLogLevel
+#define MGCDAsyncSocketLogLevel LOG_LEVEL_VERBOSE
 #endif
 
 // Log levels : off, error, warn, info, verbose
-static const int logLevel = GCDAsyncSocketLogLevel;
+static const int logLevel = MGCDAsyncSocketLogLevel;
 
 #else
 
@@ -109,28 +109,28 @@ static const int logLevel = GCDAsyncSocketLogLevel;
 #define SOCKET_NULL -1
 
 
-NSString *const GCDAsyncSocketException = @"GCDAsyncSocketException";
-NSString *const GCDAsyncSocketErrorDomain = @"GCDAsyncSocketErrorDomain";
+NSString *const MGCDAsyncSocketException = @"MGCDAsyncSocketException";
+NSString *const MGCDAsyncSocketErrorDomain = @"MGCDAsyncSocketErrorDomain";
 
-NSString *const GCDAsyncSocketQueueName = @"GCDAsyncSocket";
-NSString *const GCDAsyncSocketThreadName = @"GCDAsyncSocket-CFStream";
+NSString *const MGCDAsyncSocketQueueName = @"MGCDAsyncSocket";
+NSString *const MGCDAsyncSocketThreadName = @"MGCDAsyncSocket-CFStream";
 
-NSString *const GCDAsyncSocketManuallyEvaluateTrust = @"GCDAsyncSocketManuallyEvaluateTrust";
+NSString *const MGCDAsyncSocketManuallyEvaluateTrust = @"MGCDAsyncSocketManuallyEvaluateTrust";
 #if TARGET_OS_IPHONE
-NSString *const GCDAsyncSocketUseCFStreamForTLS = @"GCDAsyncSocketUseCFStreamForTLS";
+NSString *const MGCDAsyncSocketUseCFStreamForTLS = @"MGCDAsyncSocketUseCFStreamForTLS";
 #endif
-NSString *const GCDAsyncSocketSSLPeerID = @"GCDAsyncSocketSSLPeerID";
-NSString *const GCDAsyncSocketSSLProtocolVersionMin = @"GCDAsyncSocketSSLProtocolVersionMin";
-NSString *const GCDAsyncSocketSSLProtocolVersionMax = @"GCDAsyncSocketSSLProtocolVersionMax";
-NSString *const GCDAsyncSocketSSLSessionOptionFalseStart = @"GCDAsyncSocketSSLSessionOptionFalseStart";
-NSString *const GCDAsyncSocketSSLSessionOptionSendOneByteRecord = @"GCDAsyncSocketSSLSessionOptionSendOneByteRecord";
-NSString *const GCDAsyncSocketSSLCipherSuites = @"GCDAsyncSocketSSLCipherSuites";
-NSString *const GCDAsyncSocketSSLALPN = @"GCDAsyncSocketSSLALPN";
+NSString *const MGCDAsyncSocketSSLPeerID = @"MGCDAsyncSocketSSLPeerID";
+NSString *const MGCDAsyncSocketSSLProtocolVersionMin = @"MGCDAsyncSocketSSLProtocolVersionMin";
+NSString *const MGCDAsyncSocketSSLProtocolVersionMax = @"MGCDAsyncSocketSSLProtocolVersionMax";
+NSString *const MGCDAsyncSocketSSLSessionOptionFalseStart = @"MGCDAsyncSocketSSLSessionOptionFalseStart";
+NSString *const MGCDAsyncSocketSSLSessionOptionSendOneByteRecord = @"MGCDAsyncSocketSSLSessionOptionSendOneByteRecord";
+NSString *const MGCDAsyncSocketSSLCipherSuites = @"MGCDAsyncSocketSSLCipherSuites";
+NSString *const MGCDAsyncSocketSSLALPN = @"MGCDAsyncSocketSSLALPN";
 #if !TARGET_OS_IPHONE
-NSString *const GCDAsyncSocketSSLDiffieHellmanParameters = @"GCDAsyncSocketSSLDiffieHellmanParameters";
+NSString *const MGCDAsyncSocketSSLDiffieHellmanParameters = @"MGCDAsyncSocketSSLDiffieHellmanParameters";
 #endif
 
-enum GCDAsyncSocketFlags
+enum MGCDAsyncSocketFlags
 {
 	kSocketStarted                 = 1 <<  0,  // If set, socket has been started (accepting/connecting)
 	kConnected                     = 1 <<  1,  // If set, the socket is connected
@@ -156,7 +156,7 @@ enum GCDAsyncSocketFlags
 #endif
 };
 
-enum GCDAsyncSocketConfig
+enum MGCDAsyncSocketConfig
 {
 	kIPv4Disabled              = 1 << 0,  // If set, IPv4 is disabled
 	kIPv6Disabled              = 1 << 1,  // If set, IPv6 is disabled
@@ -194,7 +194,7 @@ enum GCDAsyncSocketConfig
  * The current design is very simple and straight-forward, while also keeping memory requirements lower.
 **/
 
-@interface GCDAsyncSocketPreBuffer : NSObject
+@interface MGCDAsyncSocketPreBuffer : NSObject
 {
 	uint8_t *preBuffer;
 	size_t preBufferSize;
@@ -224,7 +224,7 @@ enum GCDAsyncSocketConfig
 
 @end
 
-@implementation GCDAsyncSocketPreBuffer
+@implementation MGCDAsyncSocketPreBuffer
 
 // Cover the superclass' designated initializer
 - (instancetype)init NS_UNAVAILABLE
@@ -336,13 +336,13 @@ enum GCDAsyncSocketConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * The GCDAsyncReadPacket encompasses the instructions for any given read.
+ * The MGCDAsyncReadPacket encompasses the instructions for any given read.
  * The content of a read packet allows the code to determine if we're:
  *  - reading to a certain length
  *  - reading to a certain separator
  *  - or simply reading the first chunk of available data
 **/
-@interface GCDAsyncReadPacket : NSObject
+@interface MGCDAsyncReadPacket : NSObject
 {
   @public
 	NSMutableData *buffer;
@@ -370,13 +370,13 @@ enum GCDAsyncSocketConfig
 
 - (NSUInteger)readLengthForNonTermWithHint:(NSUInteger)bytesAvailable;
 - (NSUInteger)readLengthForTermWithHint:(NSUInteger)bytesAvailable shouldPreBuffer:(BOOL *)shouldPreBufferPtr;
-- (NSUInteger)readLengthForTermWithPreBuffer:(GCDAsyncSocketPreBuffer *)preBuffer found:(BOOL *)foundPtr;
+- (NSUInteger)readLengthForTermWithPreBuffer:(MGCDAsyncSocketPreBuffer *)preBuffer found:(BOOL *)foundPtr;
 
 - (NSInteger)searchForTermAfterPreBuffering:(ssize_t)numBytes;
 
 @end
 
-@implementation GCDAsyncReadPacket
+@implementation MGCDAsyncReadPacket
 
 // Cover the superclass' designated initializer
 - (instancetype)init NS_UNAVAILABLE
@@ -640,7 +640,7 @@ enum GCDAsyncSocketConfig
  * 
  * It is assumed the terminator has not already been read.
 **/
-- (NSUInteger)readLengthForTermWithPreBuffer:(GCDAsyncSocketPreBuffer *)preBuffer found:(BOOL *)foundPtr
+- (NSUInteger)readLengthForTermWithPreBuffer:(MGCDAsyncSocketPreBuffer *)preBuffer found:(BOOL *)foundPtr
 {
 	NSAssert(term != nil, @"This method does not apply to non-term reads");
 	NSAssert([preBuffer availableBytes] > 0, @"Invoked with empty pre buffer!");
@@ -812,9 +812,9 @@ enum GCDAsyncSocketConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * The GCDAsyncWritePacket encompasses the instructions for any given write.
+ * The MGCDAsyncWritePacket encompasses the instructions for any given write.
 **/
-@interface GCDAsyncWritePacket : NSObject
+@interface MGCDAsyncWritePacket : NSObject
 {
   @public
 	NSData *buffer;
@@ -825,7 +825,7 @@ enum GCDAsyncSocketConfig
 - (instancetype)initWithData:(NSData *)d timeout:(NSTimeInterval)t tag:(long)i NS_DESIGNATED_INITIALIZER;
 @end
 
-@implementation GCDAsyncWritePacket
+@implementation MGCDAsyncWritePacket
 
 // Cover the superclass' designated initializer
 - (instancetype)init NS_UNAVAILABLE
@@ -854,10 +854,10 @@ enum GCDAsyncSocketConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * The GCDAsyncSpecialPacket encompasses special instructions for interruptions in the read/write queues.
+ * The MGCDAsyncSpecialPacket encompasses special instructions for interruptions in the read/write queues.
  * This class my be altered to support more than just TLS in the future.
 **/
-@interface GCDAsyncSpecialPacket : NSObject
+@interface MGCDAsyncSpecialPacket : NSObject
 {
   @public
 	NSDictionary *tlsSettings;
@@ -865,7 +865,7 @@ enum GCDAsyncSocketConfig
 - (instancetype)initWithTLSSettings:(NSDictionary <NSString*,NSObject*>*)settings NS_DESIGNATED_INITIALIZER;
 @end
 
-@implementation GCDAsyncSpecialPacket
+@implementation MGCDAsyncSpecialPacket
 
 // Cover the superclass' designated initializer
 - (instancetype)init NS_UNAVAILABLE
@@ -890,12 +890,12 @@ enum GCDAsyncSocketConfig
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@implementation GCDAsyncSocket
+@implementation MGCDAsyncSocket
 {
 	uint32_t flags;
 	uint16_t config;
 	
-	__weak id<GCDAsyncSocketDelegate> delegate;
+	__weak id<MGCDAsyncSocketDelegate> delegate;
 	dispatch_queue_t delegateQueue;
 	
 	int socket4FD;
@@ -921,12 +921,12 @@ enum GCDAsyncSocketConfig
 	NSMutableArray *readQueue;
 	NSMutableArray *writeQueue;
 	
-	GCDAsyncReadPacket *currentRead;
-	GCDAsyncWritePacket *currentWrite;
+	MGCDAsyncReadPacket *currentRead;
+	MGCDAsyncWritePacket *currentWrite;
 	
 	unsigned long socketFDBytesAvailable;
 	
-	GCDAsyncSocketPreBuffer *preBuffer;
+	MGCDAsyncSocketPreBuffer *preBuffer;
 		
 #if TARGET_OS_IPHONE
 	CFStreamClientContext streamContext;
@@ -934,7 +934,7 @@ enum GCDAsyncSocketConfig
 	CFWriteStreamRef writeStream;
 #endif
 	SSLContextRef sslContext;
-	GCDAsyncSocketPreBuffer *sslPreBuffer;
+	MGCDAsyncSocketPreBuffer *sslPreBuffer;
 	size_t sslWriteCachedLength;
 	OSStatus sslErrCode;
     OSStatus lastSSLHandshakeError;
@@ -955,12 +955,12 @@ enum GCDAsyncSocketConfig
 	return [self initWithDelegate:nil delegateQueue:NULL socketQueue:sq];
 }
 
-- (instancetype)initWithDelegate:(id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq
+- (instancetype)initWithDelegate:(id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq
 {
 	return [self initWithDelegate:aDelegate delegateQueue:dq socketQueue:NULL];
 }
 
-- (instancetype)initWithDelegate:(id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
+- (instancetype)initWithDelegate:(id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
 {
 	if((self = [super init]))
 	{
@@ -993,7 +993,7 @@ enum GCDAsyncSocketConfig
 		}
 		else
 		{
-			socketQueue = dispatch_queue_create([GCDAsyncSocketQueueName UTF8String], NULL);
+			socketQueue = dispatch_queue_create([MGCDAsyncSocketQueueName UTF8String], NULL);
 		}
 		
 		// The dispatch_queue_set_specific() and dispatch_get_specific() functions take a "void *key" parameter.
@@ -1024,7 +1024,7 @@ enum GCDAsyncSocketConfig
 		writeQueue = [[NSMutableArray alloc] initWithCapacity:5];
 		currentWrite = nil;
 		
-		preBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
+		preBuffer = [[MGCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
         alternateAddressDelay = 0.3;
 	}
 	return self;
@@ -1070,16 +1070,16 @@ enum GCDAsyncSocketConfig
   return [self socketFromConnectedSocketFD:socketFD delegate:nil delegateQueue:NULL socketQueue:sq error:error];
 }
 
-+ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq error:(NSError**)error {
++ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq error:(NSError**)error {
   return [self socketFromConnectedSocketFD:socketFD delegate:aDelegate delegateQueue:dq socketQueue:NULL error:error];
 }
 
-+ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<GCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq error:(NSError* __autoreleasing *)error
++ (nullable instancetype)socketFromConnectedSocketFD:(int)socketFD delegate:(nullable id<MGCDAsyncSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq error:(NSError* __autoreleasing *)error
 {
   __block BOOL errorOccured = NO;
   __block NSError *thisError = nil;
   
-  GCDAsyncSocket *socket = [[[self class] alloc] initWithDelegate:aDelegate delegateQueue:dq socketQueue:sq];
+  MGCDAsyncSocket *socket = [[[self class] alloc] initWithDelegate:aDelegate delegateQueue:dq socketQueue:sq];
   
   dispatch_sync(socket->socketQueue, ^{ @autoreleasepool {
     struct sockaddr addr;
@@ -1087,14 +1087,14 @@ enum GCDAsyncSocketConfig
     int retVal = getpeername(socketFD, (struct sockaddr *)&addr, &addr_size);
     if (retVal)
     {
-      NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketOtherError",
-                                                           @"GCDAsyncSocket", [NSBundle mainBundle],
+      NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketOtherError",
+                                                           @"MGCDAsyncSocket", [NSBundle mainBundle],
                                                            @"Attempt to create socket from socket FD failed. getpeername() failed", nil);
       
       NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 
       errorOccured = YES;
-      thisError = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+      thisError = [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketOtherError userInfo:userInfo];
       return;
     }
     
@@ -1108,14 +1108,14 @@ enum GCDAsyncSocketConfig
     }
     else
     {
-      NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketOtherError",
-                                                           @"GCDAsyncSocket", [NSBundle mainBundle],
+      NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketOtherError",
+                                                           @"MGCDAsyncSocket", [NSBundle mainBundle],
                                                            @"Attempt to create socket from socket FD failed. socket FD is neither IPv4 nor IPv6", nil);
       
       NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
       
       errorOccured = YES;
-      thisError = [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+      thisError = [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketOtherError userInfo:userInfo];
       return;
     }
     
@@ -1169,12 +1169,12 @@ enum GCDAsyncSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncSocketDelegate>)newDelegate
+- (void)setDelegate:(id<MGCDAsyncSocketDelegate>)newDelegate
 {
 	[self setDelegate:newDelegate synchronously:NO];
 }
 
-- (void)synchronouslySetDelegate:(id<GCDAsyncSocketDelegate>)newDelegate
+- (void)synchronouslySetDelegate:(id<MGCDAsyncSocketDelegate>)newDelegate
 {
 	[self setDelegate:newDelegate synchronously:YES];
 }
@@ -1230,7 +1230,7 @@ enum GCDAsyncSocketConfig
 	[self setDelegateQueue:newDelegateQueue synchronously:YES];
 }
 
-- (void)getDelegate:(id<GCDAsyncSocketDelegate> *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
+- (void)getDelegate:(id<MGCDAsyncSocketDelegate> *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
 {
 	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
 	{
@@ -1277,12 +1277,12 @@ enum GCDAsyncSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
+- (void)setDelegate:(id<MGCDAsyncSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
 	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:NO];
 }
 
-- (void)synchronouslySetDelegate:(id<GCDAsyncSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
+- (void)synchronouslySetDelegate:(id<MGCDAsyncSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
 	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:YES];
 }
@@ -1673,13 +1673,13 @@ enum GCDAsyncSocketConfig
             int socketFD = self->socket4FD;
             dispatch_source_t acceptSource = self->accept4Source;
 			
-			__weak GCDAsyncSocket *weakSelf = self;
+			__weak MGCDAsyncSocket *weakSelf = self;
 			
             dispatch_source_set_event_handler(self->accept4Source, ^{ @autoreleasepool {
 			#pragma clang diagnostic push
 			#pragma clang diagnostic warning "-Wimplicit-retain-self"
 				
-				__strong GCDAsyncSocket *strongSelf = weakSelf;
+				__strong MGCDAsyncSocket *strongSelf = weakSelf;
 				if (strongSelf == nil) return_from_block;
 				
 				LogVerbose(@"event4Block");
@@ -1721,13 +1721,13 @@ enum GCDAsyncSocketConfig
             int socketFD = self->socket6FD;
             dispatch_source_t acceptSource = self->accept6Source;
 			
-			__weak GCDAsyncSocket *weakSelf = self;
+			__weak MGCDAsyncSocket *weakSelf = self;
 			
             dispatch_source_set_event_handler(self->accept6Source, ^{ @autoreleasepool {
 			#pragma clang diagnostic push
 			#pragma clang diagnostic warning "-Wimplicit-retain-self"
 				
-				__strong GCDAsyncSocket *strongSelf = weakSelf;
+				__strong MGCDAsyncSocket *strongSelf = weakSelf;
 				if (strongSelf == nil) return_from_block;
 				
 				LogVerbose(@"event6Block");
@@ -1937,11 +1937,11 @@ enum GCDAsyncSocketConfig
         int socketFD = self->socketUN;
         dispatch_source_t acceptSource = self->acceptUNSource;
 		
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
         dispatch_source_set_event_handler(self->acceptUNSource, ^{ @autoreleasepool {
 			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
+			__strong MGCDAsyncSocket *strongSelf = weakSelf;
 			
 			LogVerbose(@"eventUNBlock");
 			
@@ -2068,7 +2068,7 @@ enum GCDAsyncSocketConfig
 	
 	if (delegateQueue)
 	{
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 		
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
 			
@@ -2082,9 +2082,9 @@ enum GCDAsyncSocketConfig
 				                                                              onSocket:self];
 			}
 			
-			// Create GCDAsyncSocket instance for accepted socket
+			// Create MGCDAsyncSocket instance for accepted socket
 			
-			GCDAsyncSocket *acceptedSocket = [[[self class] alloc] initWithDelegate:theDelegate
+			MGCDAsyncSocket *acceptedSocket = [[[self class] alloc] initWithDelegate:theDelegate
                                                                       delegateQueue:self->delegateQueue
 																		socketQueue:childSocketQueue];
 			
@@ -2344,7 +2344,7 @@ enum GCDAsyncSocketConfig
 		NSString *hostCpy = [host copy];
 		
         int aStateIndex = self->stateIndex;
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
 		dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 		dispatch_async(globalConcurrentQueue, ^{ @autoreleasepool {
@@ -2354,7 +2354,7 @@ enum GCDAsyncSocketConfig
 			NSError *lookupErr = nil;
 			NSMutableArray *addresses = [[self class] lookupHost:hostCpy port:port error:&lookupErr];
 			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
+			__strong MGCDAsyncSocket *strongSelf = weakSelf;
 			if (strongSelf == nil) return_from_block;
 			
 			if (lookupErr)
@@ -2738,7 +2738,7 @@ enum GCDAsyncSocketConfig
     
     // Start the connection process in a background queue
     
-    __weak GCDAsyncSocket *weakSelf = self;
+    __weak MGCDAsyncSocket *weakSelf = self;
     
     dispatch_queue_t globalConcurrentQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
     dispatch_async(globalConcurrentQueue, ^{
@@ -2748,7 +2748,7 @@ enum GCDAsyncSocketConfig
         int result = connect(socketFD, (const struct sockaddr *)[address bytes], (socklen_t)[address length]);
         int err = errno;
         
-        __strong GCDAsyncSocket *strongSelf = weakSelf;
+        __strong MGCDAsyncSocket *strongSelf = weakSelf;
         if (strongSelf == nil) return_from_block;
         
         dispatch_async(strongSelf->socketQueue, ^{ @autoreleasepool {
@@ -3044,7 +3044,7 @@ enum GCDAsyncSocketConfig
 	uint16_t port = [self connectedPort];
 	NSURL *url = [self connectedUrl];
 	
-	__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 	if (delegateQueue && host != nil && [theDelegate respondsToSelector:@selector(socket:didConnectToHost:port:)])
 	{
@@ -3130,13 +3130,13 @@ enum GCDAsyncSocketConfig
 	{
 		connectTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
 		
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
 		dispatch_source_set_event_handler(connectTimer, ^{ @autoreleasepool {
 		#pragma clang diagnostic push
 		#pragma clang diagnostic warning "-Wimplicit-retain-self"
 		
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
+			__strong MGCDAsyncSocket *strongSelf = weakSelf;
 			if (strongSelf == nil) return_from_block;
 			
 			[strongSelf doConnectTimeout];
@@ -3365,7 +3365,7 @@ enum GCDAsyncSocketConfig
 	
 	if (shouldCallDelegate)
 	{
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 		__strong id theSelf = isDeallocating ? nil : self;
 		
 		if (delegateQueue && [theDelegate respondsToSelector: @selector(socketDidDisconnect:withError:)])
@@ -3482,14 +3482,14 @@ enum GCDAsyncSocketConfig
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadConfigError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketBadConfigError userInfo:userInfo];
 }
 
 - (NSError *)badParamError:(NSString *)errMsg
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketBadParamError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketBadParamError userInfo:userInfo];
 }
 
 + (NSError *)gaiError:(int)gai_error
@@ -3527,13 +3527,13 @@ enum GCDAsyncSocketConfig
 
 - (NSError *)connectTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketConnectTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketConnectTimeoutError",
+	                                                     @"MGCDAsyncSocket", [NSBundle mainBundle],
 	                                                     @"Attempt to connect to host timed out", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketConnectTimeoutError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketConnectTimeoutError userInfo:userInfo];
 }
 
 /**
@@ -3541,13 +3541,13 @@ enum GCDAsyncSocketConfig
 **/
 - (NSError *)readMaxedOutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadMaxedOutError",
-														 @"GCDAsyncSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketReadMaxedOutError",
+														 @"MGCDAsyncSocket", [NSBundle mainBundle],
 														 @"Read operation reached set maximum length", nil);
 	
 	NSDictionary *info = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadMaxedOutError userInfo:info];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketReadMaxedOutError userInfo:info];
 }
 
 /**
@@ -3555,13 +3555,13 @@ enum GCDAsyncSocketConfig
 **/
 - (NSError *)readTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketReadTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketReadTimeoutError",
+	                                                     @"MGCDAsyncSocket", [NSBundle mainBundle],
 	                                                     @"Read operation timed out", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketReadTimeoutError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketReadTimeoutError userInfo:userInfo];
 }
 
 /**
@@ -3569,31 +3569,31 @@ enum GCDAsyncSocketConfig
 **/
 - (NSError *)writeTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketWriteTimeoutError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketWriteTimeoutError",
+	                                                     @"MGCDAsyncSocket", [NSBundle mainBundle],
 	                                                     @"Write operation timed out", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketWriteTimeoutError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketWriteTimeoutError userInfo:userInfo];
 }
 
 - (NSError *)connectionClosedError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncSocketClosedError",
-	                                                     @"GCDAsyncSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncSocketClosedError",
+	                                                     @"MGCDAsyncSocket", [NSBundle mainBundle],
 	                                                     @"Socket closed by remote peer", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketClosedError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketClosedError userInfo:userInfo];
 }
 
 - (NSError *)otherError:(NSString *)errMsg
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncSocketErrorDomain code:GCDAsyncSocketOtherError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncSocketErrorDomain code:MGCDAsyncSocketOtherError userInfo:userInfo];
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -4261,13 +4261,13 @@ enum GCDAsyncSocketConfig
 	
 	// Setup event handlers
 	
-	__weak GCDAsyncSocket *weakSelf = self;
+	__weak MGCDAsyncSocket *weakSelf = self;
 	
 	dispatch_source_set_event_handler(readSource, ^{ @autoreleasepool {
 	#pragma clang diagnostic push
 	#pragma clang diagnostic warning "-Wimplicit-retain-self"
 		
-		__strong GCDAsyncSocket *strongSelf = weakSelf;
+		__strong MGCDAsyncSocket *strongSelf = weakSelf;
 		if (strongSelf == nil) return_from_block;
 		
 		LogVerbose(@"readEventBlock");
@@ -4287,7 +4287,7 @@ enum GCDAsyncSocketConfig
 	#pragma clang diagnostic push
 	#pragma clang diagnostic warning "-Wimplicit-retain-self"
 		
-		__strong GCDAsyncSocket *strongSelf = weakSelf;
+		__strong MGCDAsyncSocket *strongSelf = weakSelf;
 		if (strongSelf == nil) return_from_block;
 		
 		LogVerbose(@"writeEventBlock");
@@ -4366,7 +4366,7 @@ enum GCDAsyncSocketConfig
 	
 	if ((flags & kSocketSecure) && (flags & kUsingCFStreamForTLS))
 	{
-		// The startTLS method was given the GCDAsyncSocketUseCFStreamForTLS flag.
+		// The startTLS method was given the MGCDAsyncSocketUseCFStreamForTLS flag.
 		
 		return YES;
 	}
@@ -4384,7 +4384,7 @@ enum GCDAsyncSocketConfig
 	
 	if ((flags & kSocketSecure) && (flags & kUsingCFStreamForTLS))
 	{
-		// The startTLS method was given the GCDAsyncSocketUseCFStreamForTLS flag.
+		// The startTLS method was given the MGCDAsyncSocketUseCFStreamForTLS flag.
 		
 		return NO;
 	}
@@ -4466,7 +4466,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+	MGCDAsyncReadPacket *packet = [[MGCDAsyncReadPacket alloc] initWithData:buffer
 	                                                          startOffset:offset
 	                                                            maxLength:length
 	                                                              timeout:timeout
@@ -4509,7 +4509,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+	MGCDAsyncReadPacket *packet = [[MGCDAsyncReadPacket alloc] initWithData:buffer
 	                                                          startOffset:offset
 	                                                            maxLength:0
 	                                                              timeout:timeout
@@ -4571,7 +4571,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	GCDAsyncReadPacket *packet = [[GCDAsyncReadPacket alloc] initWithData:buffer
+	MGCDAsyncReadPacket *packet = [[MGCDAsyncReadPacket alloc] initWithData:buffer
 	                                                          startOffset:offset
 	                                                            maxLength:maxLength
 	                                                              timeout:timeout
@@ -4600,7 +4600,7 @@ enum GCDAsyncSocketConfig
 	
 	dispatch_block_t block = ^{
 		
-        if (!self->currentRead || ![self->currentRead isKindOfClass:[GCDAsyncReadPacket class]])
+        if (!self->currentRead || ![self->currentRead isKindOfClass:[MGCDAsyncReadPacket class]])
 		{
 			// We're not reading anything right now.
 			
@@ -4663,9 +4663,9 @@ enum GCDAsyncSocketConfig
 			[readQueue removeObjectAtIndex:0];
 			
 			
-			if ([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]])
+			if ([currentRead isKindOfClass:[MGCDAsyncSpecialPacket class]])
 			{
-				LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
+				LogVerbose(@"Dequeued MGCDAsyncSpecialPacket");
 				
 				// Attempt to start TLS
 				flags |= kStartingReadTLS;
@@ -4675,7 +4675,7 @@ enum GCDAsyncSocketConfig
 			}
 			else
 			{
-				LogVerbose(@"Dequeued GCDAsyncReadPacket");
+				LogVerbose(@"Dequeued MGCDAsyncReadPacket");
 				
 				// Setup read timer (if needed)
 				[self setupReadTimerWithTimeout:currentRead->timeout];
@@ -4894,7 +4894,7 @@ enum GCDAsyncSocketConfig
 	{
 		#if TARGET_OS_IPHONE
 		
-		// Requested CFStream, rather than SecureTransport, for TLS (via GCDAsyncSocketUseCFStreamForTLS)
+		// Requested CFStream, rather than SecureTransport, for TLS (via MGCDAsyncSocketUseCFStreamForTLS)
 		
 		estimatedBytesAvailable = 0;
 		if ((flags & kSecureSocketHasBytesAvailable) && CFReadStreamHasBytesAvailable(readStream))
@@ -5553,7 +5553,7 @@ enum GCDAsyncSocketConfig
 		// that upperbound could be smaller than the desired length.
 		waiting = YES;
 
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 		
 		if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadPartialDataOfLength:tag:)])
 		{
@@ -5667,7 +5667,7 @@ enum GCDAsyncSocketConfig
 			
 			// Notify the delegate that we're going half-duplex
 			
-			__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+			__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 			if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidCloseReadStream:)])
 			{
@@ -5759,11 +5759,11 @@ enum GCDAsyncSocketConfig
 		result = [NSData dataWithBytesNoCopy:buffer length:currentRead->bytesDone freeWhenDone:NO];
 	}
 	
-	__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReadData:withTag:)])
 	{
-		GCDAsyncReadPacket *theRead = currentRead; // Ensure currentRead retained since result may not own buffer
+		MGCDAsyncReadPacket *theRead = currentRead; // Ensure currentRead retained since result may not own buffer
 		
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
 			
@@ -5791,13 +5791,13 @@ enum GCDAsyncSocketConfig
 	{
 		readTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
 		
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
 		dispatch_source_set_event_handler(readTimer, ^{ @autoreleasepool {
 		#pragma clang diagnostic push
 		#pragma clang diagnostic warning "-Wimplicit-retain-self"
 			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
+			__strong MGCDAsyncSocket *strongSelf = weakSelf;
 			if (strongSelf == nil) return_from_block;
 			
 			[strongSelf doReadTimeout];
@@ -5834,11 +5834,11 @@ enum GCDAsyncSocketConfig
 	
 	flags |= kReadsPaused;
 	
-	__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutReadWithTag:elapsed:bytesDone:)])
 	{
-		GCDAsyncReadPacket *theRead = currentRead;
+		MGCDAsyncReadPacket *theRead = currentRead;
 		
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
 			
@@ -5893,7 +5893,7 @@ enum GCDAsyncSocketConfig
 {
 	if ([data length] == 0) return;
 	
-	GCDAsyncWritePacket *packet = [[GCDAsyncWritePacket alloc] initWithData:data timeout:timeout tag:tag];
+	MGCDAsyncWritePacket *packet = [[MGCDAsyncWritePacket alloc] initWithData:data timeout:timeout tag:tag];
 	
 	dispatch_async(socketQueue, ^{ @autoreleasepool {
 		
@@ -5916,7 +5916,7 @@ enum GCDAsyncSocketConfig
 	
 	dispatch_block_t block = ^{
 		
-        if (!self->currentWrite || ![self->currentWrite isKindOfClass:[GCDAsyncWritePacket class]])
+        if (!self->currentWrite || ![self->currentWrite isKindOfClass:[MGCDAsyncWritePacket class]])
 		{
 			// We're not writing anything right now.
 			
@@ -5973,9 +5973,9 @@ enum GCDAsyncSocketConfig
 			[writeQueue removeObjectAtIndex:0];
 			
 			
-			if ([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]])
+			if ([currentWrite isKindOfClass:[MGCDAsyncSpecialPacket class]])
 			{
-				LogVerbose(@"Dequeued GCDAsyncSpecialPacket");
+				LogVerbose(@"Dequeued MGCDAsyncSpecialPacket");
 				
 				// Attempt to start TLS
 				flags |= kStartingWriteTLS;
@@ -5985,7 +5985,7 @@ enum GCDAsyncSocketConfig
 			}
 			else
 			{
-				LogVerbose(@"Dequeued GCDAsyncWritePacket");
+				LogVerbose(@"Dequeued MGCDAsyncWritePacket");
 				
 				// Setup write timer (if needed)
 				[self setupWriteTimerWithTimeout:currentWrite->timeout];
@@ -6089,7 +6089,7 @@ enum GCDAsyncSocketConfig
 		return;
 	}
 	
-	// Note: This method is not called if currentWrite is a GCDAsyncSpecialPacket (startTLS packet)
+	// Note: This method is not called if currentWrite is a MGCDAsyncSpecialPacket (startTLS packet)
 	
 	BOOL waiting = NO;
 	NSError *error = nil;
@@ -6371,7 +6371,7 @@ enum GCDAsyncSocketConfig
 		{
 			// We're not done with the entire write, but we have written some bytes
 			
-			__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+			__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 			if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWritePartialDataOfLength:tag:)])
 			{
@@ -6402,7 +6402,7 @@ enum GCDAsyncSocketConfig
 	NSAssert(currentWrite, @"Trying to complete current write when there is no current write.");
 	
 
-	__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 	
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didWriteDataWithTag:)])
 	{
@@ -6434,13 +6434,13 @@ enum GCDAsyncSocketConfig
 	{
 		writeTimer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, socketQueue);
 		
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
 		dispatch_source_set_event_handler(writeTimer, ^{ @autoreleasepool {
 		#pragma clang diagnostic push
 		#pragma clang diagnostic warning "-Wimplicit-retain-self"
 			
-			__strong GCDAsyncSocket *strongSelf = weakSelf;
+			__strong MGCDAsyncSocket *strongSelf = weakSelf;
 			if (strongSelf == nil) return_from_block;
 			
 			[strongSelf doWriteTimeout];
@@ -6477,11 +6477,11 @@ enum GCDAsyncSocketConfig
 	
 	flags |= kWritesPaused;
 	
-	__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:shouldTimeoutWriteWithTag:elapsed:bytesDone:)])
 	{
-		GCDAsyncWritePacket *theWrite = currentWrite;
+		MGCDAsyncWritePacket *theWrite = currentWrite;
 		
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
 			
@@ -6549,7 +6549,7 @@ enum GCDAsyncSocketConfig
         tlsSettings = [NSDictionary dictionary];
     }
 	
-	GCDAsyncSpecialPacket *packet = [[GCDAsyncSpecialPacket alloc] initWithTLSSettings:tlsSettings];
+	MGCDAsyncSpecialPacket *packet = [[MGCDAsyncSpecialPacket alloc] initWithTLSSettings:tlsSettings];
 	
 	dispatch_async(socketQueue, ^{ @autoreleasepool {
 		
@@ -6581,12 +6581,12 @@ enum GCDAsyncSocketConfig
 		
 		#if TARGET_OS_IPHONE
 		{
-			GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+			MGCDAsyncSpecialPacket *tlsPacket = (MGCDAsyncSpecialPacket *)currentRead;
             NSDictionary *tlsSettings = @{};
             if (tlsPacket) {
                 tlsSettings = tlsPacket->tlsSettings;
             }
-			NSNumber *value = [tlsSettings objectForKey:GCDAsyncSocketUseCFStreamForTLS];
+			NSNumber *value = [tlsSettings objectForKey:MGCDAsyncSocketUseCFStreamForTLS];
 			if (value && [value boolValue])
 				useSecureTransport = NO;
 		}
@@ -6830,7 +6830,7 @@ enum GCDAsyncSocketConfig
 
 static OSStatus SSLReadFunction(SSLConnectionRef connection, void *data, size_t *dataLength)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
+	MGCDAsyncSocket *asyncSocket = (__bridge MGCDAsyncSocket *)connection;
 	
 	NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
 	
@@ -6839,7 +6839,7 @@ static OSStatus SSLReadFunction(SSLConnectionRef connection, void *data, size_t 
 
 static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, size_t *dataLength)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)connection;
+	MGCDAsyncSocket *asyncSocket = (__bridge MGCDAsyncSocket *)connection;
 	
 	NSCAssert(dispatch_get_specific(asyncSocket->IsOnSocketQueueOrTargetQueueKey), @"What the deuce?");
 	
@@ -6854,7 +6854,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	
 	OSStatus status;
 	
-	GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+	MGCDAsyncSpecialPacket *tlsPacket = (MGCDAsyncSpecialPacket *)currentRead;
 	if (tlsPacket == nil) // Code to quiet the analyzer
 	{
 		NSAssert(NO, @"Logic error");
@@ -6908,7 +6908,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 
 
-	NSNumber *shouldManuallyEvaluateTrust = [tlsSettings objectForKey:GCDAsyncSocketManuallyEvaluateTrust];
+	NSNumber *shouldManuallyEvaluateTrust = [tlsSettings objectForKey:MGCDAsyncSocketManuallyEvaluateTrust];
 	if ([shouldManuallyEvaluateTrust boolValue])
 	{
 		if (isServer)
@@ -6948,14 +6948,14 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	// Checklist:
 	//  1. kCFStreamSSLPeerName
 	//  2. kCFStreamSSLCertificates
-	//  3. GCDAsyncSocketSSLPeerID
-	//  4. GCDAsyncSocketSSLProtocolVersionMin
-	//  5. GCDAsyncSocketSSLProtocolVersionMax
-	//  6. GCDAsyncSocketSSLSessionOptionFalseStart
-	//  7. GCDAsyncSocketSSLSessionOptionSendOneByteRecord
-	//  8. GCDAsyncSocketSSLCipherSuites
-	//  9. GCDAsyncSocketSSLDiffieHellmanParameters (Mac)
-    // 10. GCDAsyncSocketSSLALPN
+	//  3. MGCDAsyncSocketSSLPeerID
+	//  4. MGCDAsyncSocketSSLProtocolVersionMin
+	//  5. MGCDAsyncSocketSSLProtocolVersionMax
+	//  6. MGCDAsyncSocketSSLSessionOptionFalseStart
+	//  7. MGCDAsyncSocketSSLSessionOptionSendOneByteRecord
+	//  8. MGCDAsyncSocketSSLCipherSuites
+	//  9. MGCDAsyncSocketSSLDiffieHellmanParameters (Mac)
+    // 10. MGCDAsyncSocketSSLALPN
 	//
 	// Deprecated (throw error):
 	// 10. kCFStreamSSLAllowsAnyRoot
@@ -7013,9 +7013,9 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		return;
 	}
 	
-	// 3. GCDAsyncSocketSSLPeerID
+	// 3. MGCDAsyncSocketSSLPeerID
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLPeerID];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLPeerID];
 	if ([value isKindOfClass:[NSData class]])
 	{
 		NSData *peerIdData = (NSData *)value;
@@ -7029,17 +7029,17 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLPeerID. Value must be of type NSData."
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLPeerID. Value must be of type NSData."
 		             @" (You can convert strings to data using a method like"
 		             @" [string dataUsingEncoding:NSUTF8StringEncoding])");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLPeerID."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLPeerID."]];
 		return;
 	}
 	
-	// 4. GCDAsyncSocketSSLProtocolVersionMin
+	// 4. MGCDAsyncSocketSSLProtocolVersionMin
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMin];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLProtocolVersionMin];
 	if ([value isKindOfClass:[NSNumber class]])
 	{
 		SSLProtocol minProtocol = (SSLProtocol)[(NSNumber *)value intValue];
@@ -7055,15 +7055,15 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLProtocolVersionMin. Value must be of type NSNumber.");
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLProtocolVersionMin. Value must be of type NSNumber.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLProtocolVersionMin."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLProtocolVersionMin."]];
 		return;
 	}
 	
-	// 5. GCDAsyncSocketSSLProtocolVersionMax
+	// 5. MGCDAsyncSocketSSLProtocolVersionMax
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLProtocolVersionMax];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLProtocolVersionMax];
 	if ([value isKindOfClass:[NSNumber class]])
 	{
 		SSLProtocol maxProtocol = (SSLProtocol)[(NSNumber *)value intValue];
@@ -7079,15 +7079,15 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLProtocolVersionMax. Value must be of type NSNumber.");
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLProtocolVersionMax. Value must be of type NSNumber.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLProtocolVersionMax."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLProtocolVersionMax."]];
 		return;
 	}
 	
-	// 6. GCDAsyncSocketSSLSessionOptionFalseStart
+	// 6. MGCDAsyncSocketSSLSessionOptionFalseStart
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLSessionOptionFalseStart];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLSessionOptionFalseStart];
 	if ([value isKindOfClass:[NSNumber class]])
 	{
 		NSNumber *falseStart = (NSNumber *)value;
@@ -7100,15 +7100,15 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLSessionOptionFalseStart. Value must be of type NSNumber.");
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLSessionOptionFalseStart. Value must be of type NSNumber.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLSessionOptionFalseStart."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLSessionOptionFalseStart."]];
 		return;
 	}
 	
-	// 7. GCDAsyncSocketSSLSessionOptionSendOneByteRecord
+	// 7. MGCDAsyncSocketSSLSessionOptionSendOneByteRecord
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLSessionOptionSendOneByteRecord];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLSessionOptionSendOneByteRecord];
 	if ([value isKindOfClass:[NSNumber class]])
 	{
 		NSNumber *oneByteRecord = (NSNumber *)value;
@@ -7122,16 +7122,16 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLSessionOptionSendOneByteRecord."
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLSessionOptionSendOneByteRecord."
 		             @" Value must be of type NSNumber.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLSessionOptionSendOneByteRecord."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLSessionOptionSendOneByteRecord."]];
 		return;
 	}
 	
-	// 8. GCDAsyncSocketSSLCipherSuites
+	// 8. MGCDAsyncSocketSSLCipherSuites
 	
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLCipherSuites];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLCipherSuites];
 	if ([value isKindOfClass:[NSArray class]])
 	{
 		NSArray *cipherSuites = (NSArray *)value;
@@ -7154,16 +7154,16 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLCipherSuites. Value must be of type NSArray.");
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLCipherSuites. Value must be of type NSArray.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLCipherSuites."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLCipherSuites."]];
 		return;
 	}
 	
-	// 9. GCDAsyncSocketSSLDiffieHellmanParameters
+	// 9. MGCDAsyncSocketSSLDiffieHellmanParameters
 	
 	#if !TARGET_OS_IPHONE
-	value = [tlsSettings objectForKey:GCDAsyncSocketSSLDiffieHellmanParameters];
+	value = [tlsSettings objectForKey:MGCDAsyncSocketSSLDiffieHellmanParameters];
 	if ([value isKindOfClass:[NSData class]])
 	{
 		NSData *diffieHellmanData = (NSData *)value;
@@ -7177,15 +7177,15 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	}
 	else if (value)
 	{
-		NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLDiffieHellmanParameters. Value must be of type NSData.");
+		NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLDiffieHellmanParameters. Value must be of type NSData.");
 		
-		[self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLDiffieHellmanParameters."]];
+		[self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLDiffieHellmanParameters."]];
 		return;
 	}
 	#endif
 
     // 10. kCFStreamSSLCertificates
-    value = [tlsSettings objectForKey:GCDAsyncSocketSSLALPN];
+    value = [tlsSettings objectForKey:MGCDAsyncSocketSSLALPN];
     if ([value isKindOfClass:[NSArray class]])
     {
         if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, *))
@@ -7200,16 +7200,16 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
         }
         else
         {
-            NSAssert(NO, @"Security option unavailable - GCDAsyncSocketSSLALPN"
+            NSAssert(NO, @"Security option unavailable - MGCDAsyncSocketSSLALPN"
                      @" - iOS 11.0, macOS 10.13 required");
-            [self closeWithError:[self otherError:@"Security option unavailable - GCDAsyncSocketSSLALPN"]];
+            [self closeWithError:[self otherError:@"Security option unavailable - MGCDAsyncSocketSSLALPN"]];
         }
     }
     else if (value)
     {
-        NSAssert(NO, @"Invalid value for GCDAsyncSocketSSLALPN. Value must be of type NSArray.");
+        NSAssert(NO, @"Invalid value for MGCDAsyncSocketSSLALPN. Value must be of type NSArray.");
         
-        [self closeWithError:[self otherError:@"Invalid value for GCDAsyncSocketSSLALPN."]];
+        [self closeWithError:[self otherError:@"Invalid value for MGCDAsyncSocketSSLALPN."]];
         return;
     }
     
@@ -7284,7 +7284,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	if (value)
 	{
 		NSAssert(NO, @"Security option unavailable - kCFStreamSSLLevel"
-		             @" - You must use GCDAsyncSocketSSLProtocolVersionMin & GCDAsyncSocketSSLProtocolVersionMax");
+		             @" - You must use MGCDAsyncSocketSSLProtocolVersionMin & MGCDAsyncSocketSSLProtocolVersionMax");
 		
 		[self closeWithError:[self otherError:@"Security option unavailable - kCFStreamSSLLevel"]];
 		return;
@@ -7295,7 +7295,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	// Any data in the preBuffer needs to be moved into the sslPreBuffer,
 	// as this data is now part of the secure read stream.
 	
-	sslPreBuffer = [[GCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
+	sslPreBuffer = [[MGCDAsyncSocketPreBuffer alloc] initWithCapacity:(1024 * 4)];
 	
 	size_t preBufferLength  = [preBuffer availableBytes];
 	
@@ -7338,7 +7338,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		
 		flags |=  kSocketSecure;
 		
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 		if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
 		{
@@ -7369,7 +7369,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		int aStateIndex = stateIndex;
 		dispatch_queue_t theSocketQueue = socketQueue;
 		
-		__weak GCDAsyncSocket *weakSelf = self;
+		__weak MGCDAsyncSocket *weakSelf = self;
 		
 		void (^comletionHandler)(BOOL) = ^(BOOL shouldTrust){ @autoreleasepool {
 		#pragma clang diagnostic push
@@ -7382,7 +7382,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 					trust = NULL;
 				}
 				
-				__strong GCDAsyncSocket *strongSelf = weakSelf;
+				__strong MGCDAsyncSocket *strongSelf = weakSelf;
 				if (strongSelf)
 				{
 					[strongSelf ssl_shouldTrustPeer:shouldTrust stateIndex:aStateIndex];
@@ -7392,7 +7392,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		#pragma clang diagnostic pop
 		}};
 		
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 		
 		if (delegateQueue && [theDelegate respondsToSelector:@selector(socket:didReceiveTrust:completionHandler:)])
 		{
@@ -7408,7 +7408,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 				trust = NULL;
 			}
 			
-			NSString *msg = @"GCDAsyncSocketManuallyEvaluateTrust specified in tlsSettings,"
+			NSString *msg = @"MGCDAsyncSocketManuallyEvaluateTrust specified in tlsSettings,"
 			                @" but delegate doesn't implement socket:shouldTrustPeer:";
 			
 			[self closeWithError:[self otherError:msg]];
@@ -7476,7 +7476,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		
 		flags |= kSocketSecure;
 		
-		__strong id<GCDAsyncSocketDelegate> theDelegate = delegate;
+		__strong id<MGCDAsyncSocketDelegate> theDelegate = delegate;
 
 		if (delegateQueue && [theDelegate respondsToSelector:@selector(socketDidSecure:)])
 		{
@@ -7548,10 +7548,10 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		return;
 	}
 	
-	NSAssert([currentRead isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid read packet for startTLS");
-	NSAssert([currentWrite isKindOfClass:[GCDAsyncSpecialPacket class]], @"Invalid write packet for startTLS");
+	NSAssert([currentRead isKindOfClass:[MGCDAsyncSpecialPacket class]], @"Invalid read packet for startTLS");
+	NSAssert([currentWrite isKindOfClass:[MGCDAsyncSpecialPacket class]], @"Invalid write packet for startTLS");
 	
-	GCDAsyncSpecialPacket *tlsPacket = (GCDAsyncSpecialPacket *)currentRead;
+	MGCDAsyncSpecialPacket *tlsPacket = (MGCDAsyncSpecialPacket *)currentRead;
 	CFDictionaryRef tlsSettings = (__bridge CFDictionaryRef)tlsPacket->tlsSettings;
 	
 	// Getting an error concerning kCFStreamPropertySSLSettings ?
@@ -7613,7 +7613,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	dispatch_once(&predicate, ^{
 		
 		cfstreamThreadRetainCount = 0;
-		cfstreamThreadSetupQueue = dispatch_queue_create("GCDAsyncSocket-CFStreamThreadSetup", DISPATCH_QUEUE_SERIAL);
+		cfstreamThreadSetupQueue = dispatch_queue_create("MGCDAsyncSocket-CFStreamThreadSetup", DISPATCH_QUEUE_SERIAL);
 	});
 	
 	dispatch_sync(cfstreamThreadSetupQueue, ^{ @autoreleasepool {
@@ -7669,7 +7669,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 
 + (void)cfstreamThread:(id)unused { @autoreleasepool
 {
-	[[NSThread currentThread] setName:GCDAsyncSocketThreadName];
+	[[NSThread currentThread] setName:MGCDAsyncSocketThreadName];
 	
 	LogInfo(@"CFStreamThread: Started");
 	
@@ -7694,7 +7694,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 	LogInfo(@"CFStreamThread: Stopped");
 }}
 
-+ (void)scheduleCFStreams:(GCDAsyncSocket *)asyncSocket
++ (void)scheduleCFStreams:(MGCDAsyncSocket *)asyncSocket
 {
 	LogTrace();
 	NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
@@ -7708,7 +7708,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 		CFWriteStreamScheduleWithRunLoop(asyncSocket->writeStream, runLoop, kCFRunLoopDefaultMode);
 }
 
-+ (void)unscheduleCFStreams:(GCDAsyncSocket *)asyncSocket
++ (void)unscheduleCFStreams:(MGCDAsyncSocket *)asyncSocket
 {
 	LogTrace();
 	NSAssert([NSThread currentThread] == cfstreamThread, @"Invoked on wrong thread");
@@ -7724,7 +7724,7 @@ static OSStatus SSLWriteFunction(SSLConnectionRef connection, const void *data, 
 
 static void CFReadStreamCallback (CFReadStreamRef stream, CFStreamEventType type, void *pInfo)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
+	MGCDAsyncSocket *asyncSocket = (__bridge MGCDAsyncSocket *)pInfo;
 	
 	switch(type)
 	{
@@ -7791,7 +7791,7 @@ static void CFReadStreamCallback (CFReadStreamRef stream, CFStreamEventType type
 
 static void CFWriteStreamCallback (CFWriteStreamRef stream, CFStreamEventType type, void *pInfo)
 {
-	GCDAsyncSocket *asyncSocket = (__bridge GCDAsyncSocket *)pInfo;
+	MGCDAsyncSocket *asyncSocket = (__bridge MGCDAsyncSocket *)pInfo;
 	
 	switch(type)
 	{

--- a/Source/GCD/MGCDAsyncUdpSocket.h
+++ b/Source/GCD/MGCDAsyncUdpSocket.h
@@ -1,5 +1,5 @@
 //  
-//  GCDAsyncUdpSocket
+//  MGCDAsyncUdpSocket
 //  
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson of Deusty LLC.
@@ -14,28 +14,28 @@
 #import <Availability.h>
 
 NS_ASSUME_NONNULL_BEGIN
-extern NSString *const GCDAsyncUdpSocketException;
-extern NSString *const GCDAsyncUdpSocketErrorDomain;
+extern NSString *const MGCDAsyncUdpSocketException;
+extern NSString *const MGCDAsyncUdpSocketErrorDomain;
 
-extern NSString *const GCDAsyncUdpSocketQueueName;
-extern NSString *const GCDAsyncUdpSocketThreadName;
+extern NSString *const MGCDAsyncUdpSocketQueueName;
+extern NSString *const MGCDAsyncUdpSocketThreadName;
 
-typedef NS_ERROR_ENUM(GCDAsyncUdpSocketErrorDomain, GCDAsyncUdpSocketError) {
-	GCDAsyncUdpSocketNoError = 0,          // Never used
-	GCDAsyncUdpSocketBadConfigError,       // Invalid configuration
-	GCDAsyncUdpSocketBadParamError,        // Invalid parameter was passed
-	GCDAsyncUdpSocketSendTimeoutError,     // A send operation timed out
-	GCDAsyncUdpSocketClosedError,          // The socket was closed
-	GCDAsyncUdpSocketOtherError,           // Description provided in userInfo
+typedef NS_ERROR_ENUM(MGCDAsyncUdpSocketErrorDomain, MGCDAsyncUdpSocketError) {
+	MGCDAsyncUdpSocketNoError = 0,          // Never used
+	MGCDAsyncUdpSocketBadConfigError,       // Invalid configuration
+	MGCDAsyncUdpSocketBadParamError,        // Invalid parameter was passed
+	MGCDAsyncUdpSocketSendTimeoutError,     // A send operation timed out
+	MGCDAsyncUdpSocketClosedError,          // The socket was closed
+	MGCDAsyncUdpSocketOtherError,           // Description provided in userInfo
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@class GCDAsyncUdpSocket;
+@class MGCDAsyncUdpSocket;
 
-@protocol GCDAsyncUdpSocketDelegate <NSObject>
+@protocol MGCDAsyncUdpSocketDelegate <NSObject>
 @optional
 
 /**
@@ -45,7 +45,7 @@ typedef NS_ERROR_ENUM(GCDAsyncUdpSocketErrorDomain, GCDAsyncUdpSocketError) {
  * 
  * This method is called if one of the connect methods are invoked, and the connection is successful.
 **/
-- (void)udpSocket:(GCDAsyncUdpSocket *)sock didConnectToAddress:(NSData *)address;
+- (void)udpSocket:(MGCDAsyncUdpSocket *)sock didConnectToAddress:(NSData *)address;
 
 /**
  * By design, UDP is a connectionless protocol, and connecting is not needed.
@@ -55,30 +55,30 @@ typedef NS_ERROR_ENUM(GCDAsyncUdpSocketErrorDomain, GCDAsyncUdpSocketError) {
  * This method is called if one of the connect methods are invoked, and the connection fails.
  * This may happen, for example, if a domain name is given for the host and the domain name is unable to be resolved.
 **/
-- (void)udpSocket:(GCDAsyncUdpSocket *)sock didNotConnect:(NSError * _Nullable)error;
+- (void)udpSocket:(MGCDAsyncUdpSocket *)sock didNotConnect:(NSError * _Nullable)error;
 
 /**
  * Called when the datagram with the given tag has been sent.
 **/
-- (void)udpSocket:(GCDAsyncUdpSocket *)sock didSendDataWithTag:(long)tag;
+- (void)udpSocket:(MGCDAsyncUdpSocket *)sock didSendDataWithTag:(long)tag;
 
 /**
  * Called if an error occurs while trying to send a datagram.
  * This could be due to a timeout, or something more serious such as the data being too large to fit in a sigle packet.
 **/
-- (void)udpSocket:(GCDAsyncUdpSocket *)sock didNotSendDataWithTag:(long)tag dueToError:(NSError * _Nullable)error;
+- (void)udpSocket:(MGCDAsyncUdpSocket *)sock didNotSendDataWithTag:(long)tag dueToError:(NSError * _Nullable)error;
 
 /**
  * Called when the socket has received the requested datagram.
 **/
-- (void)udpSocket:(GCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data
+- (void)udpSocket:(MGCDAsyncUdpSocket *)sock didReceiveData:(NSData *)data
                                              fromAddress:(NSData *)address
                                        withFilterContext:(nullable id)filterContext;
 
 /**
  * Called when the socket is closed.
 **/
-- (void)udpSocketDidClose:(GCDAsyncUdpSocket *)sock withError:(NSError  * _Nullable)error;
+- (void)udpSocketDidClose:(MGCDAsyncUdpSocket *)sock withError:(NSError  * _Nullable)error;
 
 @end
 
@@ -120,7 +120,7 @@ typedef NS_ERROR_ENUM(GCDAsyncUdpSocketErrorDomain, GCDAsyncUdpSocketError) {
  * 
  * Example:
  * 
- * GCDAsyncUdpSocketReceiveFilterBlock filter = ^BOOL (NSData *data, NSData *address, id *context) {
+ * MGCDAsyncUdpSocketReceiveFilterBlock filter = ^BOOL (NSData *data, NSData *address, id *context) {
  * 
  *     MyProtocolMessage *msg = [MyProtocol parseMessage:data];
  *     
@@ -130,7 +130,7 @@ typedef NS_ERROR_ENUM(GCDAsyncUdpSocketErrorDomain, GCDAsyncUdpSocketError) {
  * [udpSocket setReceiveFilter:filter withQueue:myParsingQueue];
  * 
 **/
-typedef BOOL (^GCDAsyncUdpSocketReceiveFilterBlock)(NSData *data, NSData *address, id __nullable * __nonnull context);
+typedef BOOL (^MGCDAsyncUdpSocketReceiveFilterBlock)(NSData *data, NSData *address, id __nullable * __nonnull context);
 
 /**
  * You may optionally set a send filter for the socket.
@@ -158,13 +158,13 @@ typedef BOOL (^GCDAsyncUdpSocketReceiveFilterBlock)(NSData *data, NSData *addres
  * Regardless of the return value, the delegate will be informed that the packet was successfully sent.
  *
 **/
-typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, long tag);
+typedef BOOL (^MGCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, long tag);
 
 
-@interface GCDAsyncUdpSocket : NSObject
+@interface MGCDAsyncUdpSocket : NSObject
 
 /**
- * GCDAsyncUdpSocket uses the standard delegate paradigm,
+ * MGCDAsyncUdpSocket uses the standard delegate paradigm,
  * but executes all delegate callbacks on a given delegate dispatch queue.
  * This allows for maximum concurrency, while at the same time providing easy thread safety.
  * 
@@ -172,7 +172,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * use the socket, or you will get an error.
  * 
  * The socket queue is optional.
- * If you pass NULL, GCDAsyncSocket will automatically create its own socket queue.
+ * If you pass NULL, MGCDAsyncSocket will automatically create its own socket queue.
  * If you choose to provide a socket queue, the socket queue must not be a concurrent queue,
  * then please see the discussion for the method markSocketQueueTargetQueue.
  *
@@ -180,33 +180,33 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
 **/
 - (instancetype)init;
 - (instancetype)initWithSocketQueue:(nullable dispatch_queue_t)sq;
-- (instancetype)initWithDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq;
-- (instancetype)initWithDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq;
+- (instancetype)initWithDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(nullable dispatch_queue_t)dq socketQueue:(nullable dispatch_queue_t)sq NS_DESIGNATED_INITIALIZER;
 
 #pragma mark Configuration
 
-- (nullable id<GCDAsyncUdpSocketDelegate>)delegate;
-- (void)setDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)delegate;
-- (void)synchronouslySetDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)delegate;
+- (nullable id<MGCDAsyncUdpSocketDelegate>)delegate;
+- (void)setDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)delegate;
+- (void)synchronouslySetDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)delegate;
 
 - (nullable dispatch_queue_t)delegateQueue;
 - (void)setDelegateQueue:(nullable dispatch_queue_t)delegateQueue;
 - (void)synchronouslySetDelegateQueue:(nullable dispatch_queue_t)delegateQueue;
 
-- (void)getDelegate:(id<GCDAsyncUdpSocketDelegate> __nullable * __nullable)delegatePtr delegateQueue:(dispatch_queue_t __nullable * __nullable)delegateQueuePtr;
-- (void)setDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
-- (void)synchronouslySetDelegate:(nullable id<GCDAsyncUdpSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
+- (void)getDelegate:(id<MGCDAsyncUdpSocketDelegate> __nullable * __nullable)delegatePtr delegateQueue:(dispatch_queue_t __nullable * __nullable)delegateQueuePtr;
+- (void)setDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
+- (void)synchronouslySetDelegate:(nullable id<MGCDAsyncUdpSocketDelegate>)delegate delegateQueue:(nullable dispatch_queue_t)delegateQueue;
 
 /**
  * By default, both IPv4 and IPv6 are enabled.
  * 
- * This means GCDAsyncUdpSocket automatically supports both protocols,
+ * This means MGCDAsyncUdpSocket automatically supports both protocols,
  * and can send to IPv4 or IPv6 addresses,
  * as well as receive over IPv4 and IPv6.
  * 
- * For operations that require DNS resolution, GCDAsyncUdpSocket supports both IPv4 and IPv6.
- * If a DNS lookup returns only IPv4 results, GCDAsyncUdpSocket will automatically use IPv4.
- * If a DNS lookup returns only IPv6 results, GCDAsyncUdpSocket will automatically use IPv6.
+ * For operations that require DNS resolution, MGCDAsyncUdpSocket supports both IPv4 and IPv6.
+ * If a DNS lookup returns only IPv4 results, MGCDAsyncUdpSocket will automatically use IPv4.
+ * If a DNS lookup returns only IPv6 results, MGCDAsyncUdpSocket will automatically use IPv6.
  * If a DNS lookup returns both IPv4 and IPv6 results, then the protocol used depends on the configured preference.
  * If IPv4 is preferred, then IPv4 is used.
  * If IPv6 is preferred, then IPv6 is used.
@@ -236,7 +236,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * The theoretical maximum size of any IPv4 UDP packet is UINT16_MAX = 65535.
  * The theoretical maximum size of any IPv6 UDP packet is UINT32_MAX = 4294967295.
  * 
- * Since the OS/GCD notifies us of the size of each received UDP packet,
+ * Since the OS/MGCD notifies us of the size of each received UDP packet,
  * the actual allocated buffer size for each packet is exact.
  * And in practice the size of UDP packets is generally much smaller than the max.
  * Indeed most protocols will send and receive packets of only a few bytes,
@@ -559,7 +559,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * the socket is sending it. In other words, it's not safe to alter the data until after the delegate method
  * udpSocket:didSendDataWithTag: or udpSocket:didNotSendDataWithTag:dueToError: is invoked signifying
  * that this particular send operation has completed.
- * This is due to the fact that GCDAsyncUdpSocket does NOT copy the data.
+ * This is due to the fact that MGCDAsyncUdpSocket does NOT copy the data.
  * It simply retains it for performance reasons.
  * Often times, if NSMutableData is passed, it is because a request/response was built up in memory.
  * Copying this data adds an unwanted/unneeded overhead.
@@ -608,7 +608,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * the socket is sending it. In other words, it's not safe to alter the data until after the delegate method
  * udpSocket:didSendDataWithTag: or udpSocket:didNotSendDataWithTag:dueToError: is invoked signifying
  * that this particular send operation has completed.
- * This is due to the fact that GCDAsyncUdpSocket does NOT copy the data.
+ * This is due to the fact that MGCDAsyncUdpSocket does NOT copy the data.
  * It simply retains it for performance reasons.
  * Often times, if NSMutableData is passed, it is because a request/response was built up in memory.
  * Copying this data adds an unwanted/unneeded overhead.
@@ -656,7 +656,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * the socket is sending it. In other words, it's not safe to alter the data until after the delegate method
  * udpSocket:didSendDataWithTag: or udpSocket:didNotSendDataWithTag:dueToError: is invoked signifying
  * that this particular send operation has completed.
- * This is due to the fact that GCDAsyncUdpSocket does NOT copy the data.
+ * This is due to the fact that MGCDAsyncUdpSocket does NOT copy the data.
  * It simply retains it for performance reasons.
  * Often times, if NSMutableData is passed, it is because a request/response was built up in memory.
  * Copying this data adds an unwanted/unneeded overhead.
@@ -681,13 +681,13 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  *    is more complicated than simple traffic shaping (e.g. simulating a cone port restricted router),
  *    or the system tools to handle this aren't available (e.g. on a mobile device).
  * 
- * For more information about GCDAsyncUdpSocketSendFilterBlock, see the documentation for its typedef.
+ * For more information about MGCDAsyncUdpSocketSendFilterBlock, see the documentation for its typedef.
  * To remove a previously set filter, invoke this method and pass a nil filterBlock and NULL filterQueue.
  * 
  * Note: This method invokes setSendFilter:withQueue:isAsynchronous: (documented below),
  *       passing YES for the isAsynchronous parameter.
 **/
-- (void)setSendFilter:(nullable GCDAsyncUdpSocketSendFilterBlock)filterBlock withQueue:(nullable dispatch_queue_t)filterQueue;
+- (void)setSendFilter:(nullable MGCDAsyncUdpSocketSendFilterBlock)filterBlock withQueue:(nullable dispatch_queue_t)filterQueue;
 
 /**
  * The receive filter can be run via dispatch_async or dispatch_sync.
@@ -702,7 +702,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * then you cannot perform any tasks which may invoke dispatch_sync on the socket queue.
  * For example, you can't query properties on the socket.
 **/
-- (void)setSendFilter:(nullable GCDAsyncUdpSocketSendFilterBlock)filterBlock
+- (void)setSendFilter:(nullable MGCDAsyncUdpSocketSendFilterBlock)filterBlock
             withQueue:(nullable dispatch_queue_t)filterQueue
        isAsynchronous:(BOOL)isAsynchronous;
 
@@ -765,9 +765,9 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * That is, it won't read any more packets from the underlying OS socket until beginReceiving is called again.
  * 
  * Important Note:
- * GCDAsyncUdpSocket may be running in parallel with your code.
+ * MGCDAsyncUdpSocket may be running in parallel with your code.
  * That is, your delegate is likely running on a separate thread/dispatch_queue.
- * When you invoke this method, GCDAsyncUdpSocket may have already dispatched delegate methods to be invoked.
+ * When you invoke this method, MGCDAsyncUdpSocket may have already dispatched delegate methods to be invoked.
  * Thus, if those delegate methods have already been dispatch_async'd,
  * your didReceive delegate method may still be invoked after this method has been called.
  * You should be aware of this, and program defensively.
@@ -804,7 +804,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * 
  * Example:
  * 
- * GCDAsyncUdpSocketReceiveFilterBlock filter = ^BOOL (NSData *data, NSData *address, id *context) {
+ * MGCDAsyncUdpSocketReceiveFilterBlock filter = ^BOOL (NSData *data, NSData *address, id *context) {
  * 
  *     MyProtocolMessage *msg = [MyProtocol parseMessage:data];
  *     
@@ -813,13 +813,13 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * };
  * [udpSocket setReceiveFilter:filter withQueue:myParsingQueue];
  * 
- * For more information about GCDAsyncUdpSocketReceiveFilterBlock, see the documentation for its typedef.
+ * For more information about MGCDAsyncUdpSocketReceiveFilterBlock, see the documentation for its typedef.
  * To remove a previously set filter, invoke this method and pass a nil filterBlock and NULL filterQueue.
  * 
  * Note: This method invokes setReceiveFilter:withQueue:isAsynchronous: (documented below),
  *       passing YES for the isAsynchronous parameter.
 **/
-- (void)setReceiveFilter:(nullable GCDAsyncUdpSocketReceiveFilterBlock)filterBlock withQueue:(nullable dispatch_queue_t)filterQueue;
+- (void)setReceiveFilter:(nullable MGCDAsyncUdpSocketReceiveFilterBlock)filterBlock withQueue:(nullable dispatch_queue_t)filterQueue;
 
 /**
  * The receive filter can be run via dispatch_async or dispatch_sync.
@@ -834,7 +834,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * then you cannot perform any tasks which may invoke dispatch_sync on the socket queue.
  * For example, you can't query properties on the socket.
 **/
-- (void)setReceiveFilter:(nullable GCDAsyncUdpSocketReceiveFilterBlock)filterBlock
+- (void)setReceiveFilter:(nullable MGCDAsyncUdpSocketReceiveFilterBlock)filterBlock
                withQueue:(nullable dispatch_queue_t)filterQueue
           isAsynchronous:(BOOL)isAsynchronous;
 
@@ -844,7 +844,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * Immediately closes the underlying socket.
  * Any pending send operations are discarded.
  * 
- * The GCDAsyncUdpSocket instance may optionally be used again.
+ * The MGCDAsyncUdpSocket instance may optionally be used again.
  *   (it will setup/configure/use another unnderlying BSD socket).
 **/
 - (void)close;
@@ -852,14 +852,14 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
 /**
  * Closes the underlying socket after all pending send operations have been sent.
  * 
- * The GCDAsyncUdpSocket instance may optionally be used again.
+ * The MGCDAsyncUdpSocket instance may optionally be used again.
  *   (it will setup/configure/use another unnderlying BSD socket).
 **/
 - (void)closeAfterSending;
 
 #pragma mark Advanced
 /**
- * GCDAsyncSocket maintains thread safety by using an internal serial dispatch_queue.
+ * MGCDAsyncSocket maintains thread safety by using an internal serial dispatch_queue.
  * In most cases, the instance creates this queue itself.
  * However, to allow for maximum flexibility, the internal queue may be passed in the init method.
  * This allows for some advanced options such as controlling socket priority via target queues.
@@ -892,7 +892,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * }
  *
  * What happens if you call this method from the socketTargetQueue? The result is deadlock.
- * This is because the GCD API offers no mechanism to discover a queue's targetQueue.
+ * This is because the MGCD API offers no mechanism to discover a queue's targetQueue.
  * Thus we have no idea if our socketQueue is configured with a targetQueue.
  * If we had this information, we could easily avoid deadlock.
  * But, since these API's are missing or unfeasible, you'll have to explicitly set it.
@@ -911,7 +911,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * Additionally, networking traffic from a single IP cannot monopolize the module.
  *
  * Here's how you would accomplish something like that:
- * - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(GCDAsyncSocket *)sock
+ * - (dispatch_queue_t)newSocketQueueForConnectionFromAddress:(NSData *)address onSocket:(MGCDAsyncSocket *)sock
  * {
  *     dispatch_queue_t socketQueue = dispatch_queue_create("", NULL);
  *     dispatch_queue_t ipQueue = [self ipQueueForAddress:address];
@@ -921,7 +921,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  *
  *     return socketQueue;
  * }
- * - (void)socket:(GCDAsyncSocket *)sock didAcceptNewSocket:(GCDAsyncSocket *)newSocket
+ * - (void)socket:(MGCDAsyncSocket *)sock didAcceptNewSocket:(MGCDAsyncSocket *)newSocket
  * {
  *     [clientConnections addObject:newSocket];
  *     [newSocket markSocketQueueTargetQueue:moduleQueue];
@@ -983,7 +983,7 @@ typedef BOOL (^GCDAsyncUdpSocketSendFilterBlock)(NSData *data, NSData *address, 
  * 
  * Returns (creating if necessary) a CFReadStream/CFWriteStream for the internal socket.
  * 
- * Generally GCDAsyncUdpSocket doesn't use CFStream. (It uses the faster GCD API's.)
+ * Generally MGCDAsyncUdpSocket doesn't use CFStream. (It uses the faster MGCD API's.)
  * However, if you need one for any reason,
  * these methods are a convenient way to get access to a safe instance of one.
 **/

--- a/Source/GCD/MGCDAsyncUdpSocket.m
+++ b/Source/GCD/MGCDAsyncUdpSocket.m
@@ -1,5 +1,5 @@
 //  
-//  GCDAsyncUdpSocket
+//  MGCDAsyncUdpSocket
 //  
 //  This class is in the public domain.
 //  Originally created by Robbie Hanson of Deusty LLC.
@@ -8,7 +8,7 @@
 //  https://github.com/robbiehanson/CocoaAsyncSocket
 //
 
-#import "GCDAsyncUdpSocket.h"
+#import "MGCDAsyncUdpSocket.h"
 
 #if ! __has_feature(objc_arc)
 #warning This file must be compiled with ARC. Use -fobjc-arc flag (or convert project to ARC).
@@ -33,7 +33,7 @@
 
 // Logging Enabled - See log level below
 
-// Logging uses the CocoaLumberjack framework (which is also GCD based).
+// Logging uses the CocoaLumberjack framework (which is also MGCD based).
 // https://github.com/robbiehanson/CocoaLumberjack
 // 
 // It allows us to do a lot of logging without significantly slowing down the code.
@@ -100,15 +100,15 @@ static const int logLevel = LOG_LEVEL_VERBOSE;
 #define AutoreleasedBlock(block) ^{ @autoreleasepool { block(); }} 
 
 
-@class GCDAsyncUdpSendPacket;
+@class MGCDAsyncUdpSendPacket;
 
-NSString *const GCDAsyncUdpSocketException = @"GCDAsyncUdpSocketException";
-NSString *const GCDAsyncUdpSocketErrorDomain = @"GCDAsyncUdpSocketErrorDomain";
+NSString *const MGCDAsyncUdpSocketException = @"MGCDAsyncUdpSocketException";
+NSString *const MGCDAsyncUdpSocketErrorDomain = @"MGCDAsyncUdpSocketErrorDomain";
 
-NSString *const GCDAsyncUdpSocketQueueName = @"GCDAsyncUdpSocket";
-NSString *const GCDAsyncUdpSocketThreadName = @"GCDAsyncUdpSocket-CFStream";
+NSString *const MGCDAsyncUdpSocketQueueName = @"MGCDAsyncUdpSocket";
+NSString *const MGCDAsyncUdpSocketThreadName = @"MGCDAsyncUdpSocket-CFStream";
 
-enum GCDAsyncUdpSocketFlags
+enum MGCDAsyncUdpSocketFlags
 {
 	kDidCreateSockets        = 1 <<  0,  // If set, the sockets have been created.
 	kDidBind                 = 1 <<  1,  // If set, bind has been called.
@@ -132,7 +132,7 @@ enum GCDAsyncUdpSocketFlags
 #endif
 };
 
-enum GCDAsyncUdpSocketConfig
+enum MGCDAsyncUdpSocketConfig
 {
 	kIPv4Disabled  = 1 << 0,  // If set, IPv4 is disabled
 	kIPv6Disabled  = 1 << 1,  // If set, IPv6 is disabled
@@ -144,7 +144,7 @@ enum GCDAsyncUdpSocketConfig
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@interface GCDAsyncUdpSocket ()
+@interface MGCDAsyncUdpSocket ()
 {
 #if __has_feature(objc_arc_weak)
 	__weak id delegate;
@@ -153,11 +153,11 @@ enum GCDAsyncUdpSocketConfig
 #endif
 	dispatch_queue_t delegateQueue;
 	
-	GCDAsyncUdpSocketReceiveFilterBlock receiveFilterBlock;
+	MGCDAsyncUdpSocketReceiveFilterBlock receiveFilterBlock;
 	dispatch_queue_t receiveFilterQueue;
 	BOOL receiveFilterAsync;
 	
-	GCDAsyncUdpSocketSendFilterBlock sendFilterBlock;
+	MGCDAsyncUdpSocketSendFilterBlock sendFilterBlock;
 	dispatch_queue_t sendFilterQueue;
 	BOOL sendFilterAsync;
 	
@@ -180,7 +180,7 @@ enum GCDAsyncUdpSocketConfig
 	dispatch_source_t receive6Source;
 	dispatch_source_t sendTimer;
 	
-	GCDAsyncUdpSendPacket *currentSend;
+	MGCDAsyncUdpSendPacket *currentSend;
 	NSMutableArray *sendQueue;
 	
 	unsigned long socket4FDBytesAvailable;
@@ -263,9 +263,9 @@ enum GCDAsyncUdpSocketConfig
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 /**
- * The GCDAsyncUdpSendPacket encompasses the instructions for a single send/write.
+ * The MGCDAsyncUdpSendPacket encompasses the instructions for a single send/write.
 **/
-@interface GCDAsyncUdpSendPacket : NSObject {
+@interface MGCDAsyncUdpSendPacket : NSObject {
 @public
 	NSData *buffer;
 	NSTimeInterval timeout;
@@ -285,7 +285,7 @@ enum GCDAsyncUdpSocketConfig
 
 @end
 
-@implementation GCDAsyncUdpSendPacket
+@implementation MGCDAsyncUdpSendPacket
 
 // Cover the superclass' designated initializer
 - (instancetype)init NS_UNAVAILABLE
@@ -314,7 +314,7 @@ enum GCDAsyncUdpSocketConfig
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@interface GCDAsyncUdpSpecialPacket : NSObject {
+@interface MGCDAsyncUdpSpecialPacket : NSObject {
 @public
 //	uint8_t type;
 	
@@ -328,7 +328,7 @@ enum GCDAsyncUdpSocketConfig
 
 @end
 
-@implementation GCDAsyncUdpSpecialPacket
+@implementation MGCDAsyncUdpSpecialPacket
 
 - (instancetype)init
 {
@@ -343,7 +343,7 @@ enum GCDAsyncUdpSocketConfig
 #pragma mark -
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-@implementation GCDAsyncUdpSocket
+@implementation MGCDAsyncUdpSocket
 
 - (instancetype)init
 {
@@ -359,14 +359,14 @@ enum GCDAsyncUdpSocketConfig
 	return [self initWithDelegate:nil delegateQueue:NULL socketQueue:sq];
 }
 
-- (instancetype)initWithDelegate:(id<GCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq
+- (instancetype)initWithDelegate:(id<MGCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq
 {
 	LogTrace();
 	
 	return [self initWithDelegate:aDelegate delegateQueue:dq socketQueue:NULL];
 }
 
-- (instancetype)initWithDelegate:(id<GCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
+- (instancetype)initWithDelegate:(id<MGCDAsyncUdpSocketDelegate>)aDelegate delegateQueue:(dispatch_queue_t)dq socketQueue:(dispatch_queue_t)sq
 {
 	LogTrace();
 	
@@ -406,7 +406,7 @@ enum GCDAsyncUdpSocketConfig
 		}
 		else
 		{
-			socketQueue = dispatch_queue_create([GCDAsyncUdpSocketQueueName UTF8String], NULL);
+			socketQueue = dispatch_queue_create([MGCDAsyncUdpSocketQueueName UTF8String], NULL);
 		}
 
 		// The dispatch_queue_set_specific() and dispatch_get_specific() functions take a "void *key" parameter.
@@ -481,7 +481,7 @@ enum GCDAsyncUdpSocketConfig
 #pragma mark Configuration
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (id<GCDAsyncUdpSocketDelegate>)delegate
+- (id<MGCDAsyncUdpSocketDelegate>)delegate
 {
 	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
 	{
@@ -499,7 +499,7 @@ enum GCDAsyncUdpSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate synchronously:(BOOL)synchronously
+- (void)setDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate synchronously:(BOOL)synchronously
 {
 	dispatch_block_t block = ^{
         self->delegate = newDelegate;
@@ -516,12 +516,12 @@ enum GCDAsyncUdpSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate
+- (void)setDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate
 {
 	[self setDelegate:newDelegate synchronously:NO];
 }
 
-- (void)synchronouslySetDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate
+- (void)synchronouslySetDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate
 {
 	[self setDelegate:newDelegate synchronously:YES];
 }
@@ -577,7 +577,7 @@ enum GCDAsyncUdpSocketConfig
 	[self setDelegateQueue:newDelegateQueue synchronously:YES];
 }
 
-- (void)getDelegate:(id<GCDAsyncUdpSocketDelegate> *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
+- (void)getDelegate:(id<MGCDAsyncUdpSocketDelegate> *)delegatePtr delegateQueue:(dispatch_queue_t *)delegateQueuePtr
 {
 	if (dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey))
 	{
@@ -599,7 +599,7 @@ enum GCDAsyncUdpSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue synchronously:(BOOL)synchronously
+- (void)setDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue synchronously:(BOOL)synchronously
 {
 	dispatch_block_t block = ^{
 		
@@ -624,12 +624,12 @@ enum GCDAsyncUdpSocketConfig
 	}
 }
 
-- (void)setDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
+- (void)setDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
 	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:NO];
 }
 
-- (void)synchronouslySetDelegate:(id<GCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
+- (void)synchronouslySetDelegate:(id<MGCDAsyncUdpSocketDelegate>)newDelegate delegateQueue:(dispatch_queue_t)newDelegateQueue
 {
 	[self setDelegate:newDelegate delegateQueue:newDelegateQueue synchronously:YES];
 }
@@ -948,7 +948,7 @@ enum GCDAsyncUdpSocketConfig
 {
 	LogTrace();
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(udpSocket:didConnectToAddress:)])
 	{
 		NSData *address = [anAddress copy]; // In case param is NSMutableData
@@ -964,7 +964,7 @@ enum GCDAsyncUdpSocketConfig
 {
 	LogTrace();
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(udpSocket:didNotConnect:)])
 	{
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
@@ -978,7 +978,7 @@ enum GCDAsyncUdpSocketConfig
 {
 	LogTrace();
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(udpSocket:didSendDataWithTag:)])
 	{
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
@@ -992,7 +992,7 @@ enum GCDAsyncUdpSocketConfig
 {
 	LogTrace();
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(udpSocket:didNotSendDataWithTag:dueToError:)])
 	{
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
@@ -1008,7 +1008,7 @@ enum GCDAsyncUdpSocketConfig
 	
 	SEL selector = @selector(udpSocket:didReceiveData:fromAddress:withFilterContext:);
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:selector])
 	{
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
@@ -1022,7 +1022,7 @@ enum GCDAsyncUdpSocketConfig
 {
 	LogTrace();
 	
-	__strong id<GCDAsyncUdpSocketDelegate> theDelegate = delegate;
+	__strong id<MGCDAsyncUdpSocketDelegate> theDelegate = delegate;
 	if (delegateQueue && [theDelegate respondsToSelector:@selector(udpSocketDidClose:withError:)])
 	{
 		dispatch_async(delegateQueue, ^{ @autoreleasepool {
@@ -1040,8 +1040,8 @@ enum GCDAsyncUdpSocketConfig
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncUdpSocketErrorDomain
-	                           code:GCDAsyncUdpSocketBadConfigError
+	return [NSError errorWithDomain:MGCDAsyncUdpSocketErrorDomain
+	                           code:MGCDAsyncUdpSocketBadConfigError
 	                       userInfo:userInfo];
 }
 
@@ -1049,8 +1049,8 @@ enum GCDAsyncUdpSocketConfig
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncUdpSocketErrorDomain
-	                           code:GCDAsyncUdpSocketBadParamError
+	return [NSError errorWithDomain:MGCDAsyncUdpSocketErrorDomain
+	                           code:MGCDAsyncUdpSocketBadParamError
 	                       userInfo:userInfo];
 }
 
@@ -1086,34 +1086,34 @@ enum GCDAsyncUdpSocketConfig
 **/
 - (NSError *)sendTimeoutError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncUdpSocketSendTimeoutError",
-	                                                     @"GCDAsyncUdpSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncUdpSocketSendTimeoutError",
+	                                                     @"MGCDAsyncUdpSocket", [NSBundle mainBundle],
 	                                                     @"Send operation timed out", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncUdpSocketErrorDomain
-	                           code:GCDAsyncUdpSocketSendTimeoutError
+	return [NSError errorWithDomain:MGCDAsyncUdpSocketErrorDomain
+	                           code:MGCDAsyncUdpSocketSendTimeoutError
 	                       userInfo:userInfo];
 }
 
 - (NSError *)socketClosedError
 {
-	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"GCDAsyncUdpSocketClosedError",
-	                                                     @"GCDAsyncUdpSocket", [NSBundle mainBundle],
+	NSString *errMsg = NSLocalizedStringWithDefaultValue(@"MGCDAsyncUdpSocketClosedError",
+	                                                     @"MGCDAsyncUdpSocket", [NSBundle mainBundle],
 	                                                     @"Socket closed", nil);
 	
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncUdpSocketErrorDomain code:GCDAsyncUdpSocketClosedError userInfo:userInfo];
+	return [NSError errorWithDomain:MGCDAsyncUdpSocketErrorDomain code:MGCDAsyncUdpSocketClosedError userInfo:userInfo];
 }
 
 - (NSError *)otherError:(NSString *)errMsg
 {
 	NSDictionary *userInfo = @{NSLocalizedDescriptionKey : errMsg};
 	
-	return [NSError errorWithDomain:GCDAsyncUdpSocketErrorDomain
-	                           code:GCDAsyncUdpSocketOtherError
+	return [NSError errorWithDomain:MGCDAsyncUdpSocketErrorDomain
+	                           code:MGCDAsyncUdpSocketOtherError
 	                       userInfo:userInfo];
 }
 
@@ -2034,8 +2034,8 @@ enum GCDAsyncUdpSocketConfig
          *
          * The default maximum size of the UDP buffer in iOS is 9216 bytes.
          *
-         * This is the reason of #222(GCD does not necessarily return the size of an entire UDP packet) and
-         *  #535(GCDAsyncUDPSocket can not send data when data is greater than 9K)
+         * This is the reason of #222(MGCD does not necessarily return the size of an entire UDP packet) and
+         *  #535(MGCDAsyncUDPSocket can not send data when data is greater than 9K)
          *
          *
          * Enlarge the maximum size of UDP packet.
@@ -3145,7 +3145,7 @@ enum GCDAsyncUdpSocketConfig
 		
 		// Create special connect packet
 		
-		GCDAsyncUdpSpecialPacket *packet = [[GCDAsyncUdpSpecialPacket alloc] init];
+		MGCDAsyncUdpSpecialPacket *packet = [[MGCDAsyncUdpSpecialPacket alloc] init];
 		packet->resolveInProgress = YES;
 		
 		// Start asynchronous DNS resolve for host:port on background queue
@@ -3230,7 +3230,7 @@ enum GCDAsyncUdpSocketConfig
 		NSData *address = [remoteAddr copy];
 		NSArray *addresses = [NSArray arrayWithObject:address];
 		
-		GCDAsyncUdpSpecialPacket *packet = [[GCDAsyncUdpSpecialPacket alloc] init];
+		MGCDAsyncUdpSpecialPacket *packet = [[MGCDAsyncUdpSpecialPacket alloc] init];
 		packet->addresses = addresses;
 		
 		// Updates flags, add connect packet to send queue, and pump send queue
@@ -3263,11 +3263,11 @@ enum GCDAsyncUdpSocketConfig
 	NSAssert(dispatch_get_specific(IsOnSocketQueueOrTargetQueueKey), @"Must be dispatched on socketQueue");
 	
 	
-	BOOL sendQueueReady = [currentSend isKindOfClass:[GCDAsyncUdpSpecialPacket class]];
+	BOOL sendQueueReady = [currentSend isKindOfClass:[MGCDAsyncUdpSpecialPacket class]];
 	
 	if (sendQueueReady)
 	{
-		GCDAsyncUdpSpecialPacket *connectPacket = (GCDAsyncUdpSpecialPacket *)currentSend;
+		MGCDAsyncUdpSpecialPacket *connectPacket = (MGCDAsyncUdpSpecialPacket *)currentSend;
 		
 		if (connectPacket->resolveInProgress)
 		{
@@ -3785,7 +3785,7 @@ enum GCDAsyncUdpSocketConfig
     
     
 	
-	GCDAsyncUdpSendPacket *packet = [[GCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
+	MGCDAsyncUdpSendPacket *packet = [[MGCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
 	
 	dispatch_async(socketQueue, ^{ @autoreleasepool {
 		
@@ -3809,7 +3809,7 @@ enum GCDAsyncUdpSocketConfig
 		return;
 	}
 	
-	GCDAsyncUdpSendPacket *packet = [[GCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
+	MGCDAsyncUdpSendPacket *packet = [[MGCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
 	packet->resolveInProgress = YES;
 	
 	[self asyncResolveHost:host port:port withCompletionBlock:^(NSArray *addresses, NSError *error) {
@@ -3849,8 +3849,8 @@ enum GCDAsyncUdpSocketConfig
 		return;
 	}
 	
-	GCDAsyncUdpSendPacket *packet = [[GCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
-	packet->addressFamily = [GCDAsyncUdpSocket familyFromAddress:remoteAddr];
+	MGCDAsyncUdpSendPacket *packet = [[MGCDAsyncUdpSendPacket alloc] initWithData:data timeout:timeout tag:tag];
+	packet->addressFamily = [MGCDAsyncUdpSocket familyFromAddress:remoteAddr];
 	packet->address = remoteAddr;
 	
 	dispatch_async(socketQueue, ^{ @autoreleasepool {
@@ -3860,16 +3860,16 @@ enum GCDAsyncUdpSocketConfig
 	}});
 }
 
-- (void)setSendFilter:(GCDAsyncUdpSocketSendFilterBlock)filterBlock withQueue:(dispatch_queue_t)filterQueue
+- (void)setSendFilter:(MGCDAsyncUdpSocketSendFilterBlock)filterBlock withQueue:(dispatch_queue_t)filterQueue
 {
 	[self setSendFilter:filterBlock withQueue:filterQueue isAsynchronous:YES];
 }
 
-- (void)setSendFilter:(GCDAsyncUdpSocketSendFilterBlock)filterBlock
+- (void)setSendFilter:(MGCDAsyncUdpSocketSendFilterBlock)filterBlock
             withQueue:(dispatch_queue_t)filterQueue
        isAsynchronous:(BOOL)isAsynchronous
 {
-	GCDAsyncUdpSocketSendFilterBlock newFilterBlock = NULL;
+	MGCDAsyncUdpSocketSendFilterBlock newFilterBlock = NULL;
 	dispatch_queue_t newFilterQueue = NULL;
 	
 	if (filterBlock)
@@ -3925,7 +3925,7 @@ enum GCDAsyncUdpSocketConfig
 			currentSend = [sendQueue objectAtIndex:0];
 			[sendQueue removeObjectAtIndex:0];
 			
-			if ([currentSend isKindOfClass:[GCDAsyncUdpSpecialPacket class]])
+			if ([currentSend isKindOfClass:[MGCDAsyncUdpSpecialPacket class]])
 			{
 				[self maybeConnect];
 				
@@ -4066,7 +4066,7 @@ enum GCDAsyncUdpSocketConfig
 			// Scenario 1 of 3 - Need to asynchronously query sendFilter
 			
 			currentSend->filterInProgress = YES;
-			GCDAsyncUdpSendPacket *sendPacket = currentSend;
+			MGCDAsyncUdpSendPacket *sendPacket = currentSend;
 			
 			dispatch_async(sendFilterQueue, ^{ @autoreleasepool {
 				
@@ -4415,16 +4415,16 @@ enum GCDAsyncUdpSocketConfig
 		dispatch_async(socketQueue, block);
 }
 
-- (void)setReceiveFilter:(GCDAsyncUdpSocketReceiveFilterBlock)filterBlock withQueue:(dispatch_queue_t)filterQueue
+- (void)setReceiveFilter:(MGCDAsyncUdpSocketReceiveFilterBlock)filterBlock withQueue:(dispatch_queue_t)filterQueue
 {
 	[self setReceiveFilter:filterBlock withQueue:filterQueue isAsynchronous:YES];
 }
 
-- (void)setReceiveFilter:(GCDAsyncUdpSocketReceiveFilterBlock)filterBlock
+- (void)setReceiveFilter:(MGCDAsyncUdpSocketReceiveFilterBlock)filterBlock
                withQueue:(dispatch_queue_t)filterQueue
           isAsynchronous:(BOOL)isAsynchronous
 {
-	GCDAsyncUdpSocketReceiveFilterBlock newFilterBlock = NULL;
+	MGCDAsyncUdpSocketReceiveFilterBlock newFilterBlock = NULL;
 	dispatch_queue_t newFilterQueue = NULL;
 	
 	if (filterBlock)
@@ -4552,7 +4552,7 @@ enum GCDAsyncUdpSocketConfig
 		struct sockaddr_in sockaddr4;
 		socklen_t sockaddr4len = sizeof(sockaddr4);
 		
-		// #222: GCD does not necessarily return the size of an entire UDP packet 
+		// #222: MGCD does not necessarily return the size of an entire UDP packet 
 		// from dispatch_source_get_data(), so we must use the maximum packet size.
 		size_t bufSize = max4ReceiveSize;
 		void *buf = malloc(bufSize);
@@ -4589,7 +4589,7 @@ enum GCDAsyncUdpSocketConfig
 		struct sockaddr_in6 sockaddr6;
 		socklen_t sockaddr6len = sizeof(sockaddr6);
 		
-		// #222: GCD does not necessarily return the size of an entire UDP packet 
+		// #222: MGCD does not necessarily return the size of an entire UDP packet 
 		// from dispatch_source_get_data(), so we must use the maximum packet size.
 		size_t bufSize = max6ReceiveSize;
 		void *buf = malloc(bufSize);
@@ -4870,7 +4870,7 @@ static NSThread *listenerThread;
 {
 	@autoreleasepool {
 	
-		[[NSThread currentThread] setName:GCDAsyncUdpSocketThreadName];
+		[[NSThread currentThread] setName:MGCDAsyncUdpSocketThreadName];
 		
 		LogInfo(@"ListenerThread: Started");
 		
@@ -4888,7 +4888,7 @@ static NSThread *listenerThread;
 	}
 }
 
-+ (void)addStreamListener:(GCDAsyncUdpSocket *)asyncUdpSocket
++ (void)addStreamListener:(MGCDAsyncUdpSocket *)asyncUdpSocket
 {
 	LogTrace();
 	NSAssert([NSThread currentThread] == listenerThread, @"Invoked on wrong thread");
@@ -4908,7 +4908,7 @@ static NSThread *listenerThread;
 		CFWriteStreamScheduleWithRunLoop(asyncUdpSocket->writeStream6, runLoop, kCFRunLoopDefaultMode);
 }
 
-+ (void)removeStreamListener:(GCDAsyncUdpSocket *)asyncUdpSocket
++ (void)removeStreamListener:(MGCDAsyncUdpSocket *)asyncUdpSocket
 {
 	LogTrace();
 	NSAssert([NSThread currentThread] == listenerThread, @"Invoked on wrong thread");
@@ -4931,7 +4931,7 @@ static NSThread *listenerThread;
 static void CFReadStreamCallback(CFReadStreamRef stream, CFStreamEventType type, void *pInfo)
 {
 	@autoreleasepool {
-		GCDAsyncUdpSocket *asyncUdpSocket = (__bridge GCDAsyncUdpSocket *)pInfo;
+		MGCDAsyncUdpSocket *asyncUdpSocket = (__bridge MGCDAsyncUdpSocket *)pInfo;
 	
 		switch(type)
 		{
@@ -4983,7 +4983,7 @@ static void CFReadStreamCallback(CFReadStreamRef stream, CFStreamEventType type,
 static void CFWriteStreamCallback(CFWriteStreamRef stream, CFStreamEventType type, void *pInfo)
 {
 	@autoreleasepool {
-		GCDAsyncUdpSocket *asyncUdpSocket = (__bridge GCDAsyncUdpSocket *)pInfo;
+		MGCDAsyncUdpSocket *asyncUdpSocket = (__bridge MGCDAsyncUdpSocket *)pInfo;
 		
 		switch(type)
 		{

--- a/Source/MqttCocoaAsyncSocket.h
+++ b/Source/MqttCocoaAsyncSocket.h
@@ -14,5 +14,5 @@ FOUNDATION_EXPORT double cocoaAsyncSocketVersionNumber;
 //! Project version string for CocoaAsyncSocket.
 FOUNDATION_EXPORT const unsigned char cocoaAsyncSocketVersionString[];
 
-#import "GCDAsyncSocket.h"
-#import "GCDAsyncUdpSocket.h"
+#import "MGCDAsyncSocket.h"
+#import "MGCDAsyncUdpSocket.h"


### PR DESCRIPTION
Class names starting with "GCD" conflict with [robbiehanson/CocoaAsyncSocket](https://github.com/robbiehanson/CocoaAsyncSocket), which is a different package now. Xcode gets confused when both are used in a single project – see https://github.com/emqx/CocoaMQTT/issues/493.